### PR TITLE
fix: detect opencode jsonc config files

### DIFF
--- a/lua/opencode/config_file.lua
+++ b/lua/opencode/config_file.lua
@@ -11,7 +11,9 @@ M.ConfigKeys = {
 
 local config_files_names = {
   'config.json',
+  'config.jsonc',
   'opencode.json',
+  'opencode.jsonc',
 }
 
 function M.setup()


### PR DESCRIPTION
Opencode supports jsonc config files but this plugin is not detecting them: https://opencode.ai/docs/config/#format