### PR TITLE
fix: set `winfixheight` and `winfixwidth` for input/output windows

### DIFF
--- a/lua/opencode/ui/input_window.lua
+++ b/lua/opencode/ui/input_window.lua
@@ -69,6 +69,8 @@ function M.setup(windows)
   vim.api.nvim_set_option_value('swapfile', false, { buf = windows.input_buf })
   vim.b[windows.input_buf].completion = false
   vim.api.nvim_set_option_value('winfixbuf', true, { win = windows.input_win })
+  vim.api.nvim_set_option_value('winfixheight', true, { win = windows.input_win })
+  vim.api.nvim_set_option_value('winfixwidth', true, { win = windows.input_win })
 
   M.update_dimensions(windows)
   M.refresh_placeholder(windows)

--- a/lua/opencode/ui/output_window.lua
+++ b/lua/opencode/ui/output_window.lua
@@ -43,6 +43,8 @@ function M.setup(windows)
   vim.api.nvim_set_option_value('buftype', 'nofile', { buf = windows.output_buf })
   vim.api.nvim_set_option_value('swapfile', false, { buf = windows.output_buf })
   vim.api.nvim_set_option_value('winfixbuf', true, { win = windows.output_win })
+  vim.api.nvim_set_option_value('winfixheight', true, { win = windows.output_win })
+  vim.api.nvim_set_option_value('winfixwidth', true, { win = windows.output_win })
 
   M.update_dimensions(windows)
   M.setup_keymaps(windows)


### PR DESCRIPTION
Set `winfixheight` and `winfixwidth` for input/output windows so that `<C-w>=` or opening/closing normal split windows will not accidentally resize the opencode windows.