### PR TITLE
fix: footer 'invalid window id' error when closing the output window

### DIFF
--- a/lua/opencode/ui/footer.lua
+++ b/lua/opencode/ui/footer.lua
@@ -91,7 +91,10 @@ end
 
 function M.mounted(windows)
   windows = state.windows
-  return windows and windows.footer_win and vim.api.nvim_win_is_valid(windows.footer_win)
+  return windows
+    and windows.footer_win
+    and vim.api.nvim_win_is_valid(windows.footer_win)
+    and vim.api.nvim_win_is_valid(windows.output_win)
 end
 
 function M.update_window(windows)


### PR DESCRIPTION
Getting the following error on pressing `<C-w>c` in the output window:

<img width="1882" height="245" alt="image" src="https://github.com/user-attachments/assets/facf1ce7-3ed6-4a78-a7dd-b311cf7c6483" />

This PR fixes this issue by validating output window before updating the footer window.
