### PR TITLE
feat: allow disabling buf-local keymaps

### DIFF
--- a/lua/opencode/keymap.lua
+++ b/lua/opencode/keymap.lua
@@ -18,12 +18,16 @@ function M.setup(keymap)
   end
 end
 
----@param lhs string The left-hand side of the mapping
+---@param lhs string|false The left-hand side of the mapping, `false` disables keymaps
 ---@param rhs function|string The right-hand side of the mapping
 ---@param bufnrs number|number[] Buffer number(s) to set the mapping for
 ---@param mode string|string[] Agent(s) for the mapping
 ---@param opts? table Additional options for vim.keymap.set
 function M.buf_keymap(lhs, rhs, bufnrs, mode, opts)
+  if not lhs then
+    return
+  end
+
   opts = opts or { silent = true }
   bufnrs = type(bufnrs) == 'table' and bufnrs or { bufnrs }
 

--- a/tests/unit/keymap_spec.lua
+++ b/tests/unit/keymap_spec.lua
@@ -133,4 +133,21 @@ describe('opencode.keymap', function()
       end
     end)
   end)
+
+  describe('buf_keymap', function()
+    it('does not set keymaps when lhs is false', function()
+      local bufnr = vim.api.nvim_create_buf(false, true)
+
+      -- Should not set any keymap
+      keymap.buf_keymap(false, function() end, bufnr, 'n')
+      assert.equal(0, #set_keymaps, 'No keymaps should be set when lhs is false')
+
+      -- Should set keymap
+      keymap.buf_keymap('<leader>test', function() end, bufnr, 'n')
+      assert.equal(1, #set_keymaps, 'Keymap should be set when lhs is valid')
+      assert.equal('<leader>test', set_keymaps[1].key, 'Keymap key should match provided lhs')
+
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
+  end)
 end)


### PR DESCRIPTION
Currently, each window action must have a corresponding keymap, and there is no way to disable buf-local keymaps. Buf-local keymaps should be disabled if it is assigned to `false`, which aligns with the global keymap config.

Example use case: I have `<Tab>` remapped to tabout, so I don't want it to be mapped to "toggle pane". I also prefer to switch between input/output panel directly with `<M-j/k>` (mapped to `<C-w>j/k`), so I'd rather not assign a keymap for the "toggle pane" action.