### PR TITLE
fix: standardize relative path

### DIFF
--- a/lua/opencode/context.lua
+++ b/lua/opencode/context.lua
@@ -101,6 +101,8 @@ function M.add_file(file)
     return
   end
 
+  file = vim.fn.fnamemodify(file, ':p')
+
   if not vim.tbl_contains(M.context.mentioned_files, file) then
     table.insert(M.context.mentioned_files, file)
   end


### PR DESCRIPTION
Fix for #28.

Inside of a node project with a `baseUrl` of `src`, opencode is looking for `/pages/...` when the file was at `src/pages/...`. 

Expanding the path to an absolute, normalized path with `fnamemodify` fixes this.