### PR TITLE
fix: broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ To configure user commands
 
 <img src="https://i.imgur.com/YQhhoPS.png" alt="Opencode.nvim contextual actions" width="90%" />
 
-See [User Commands Documentation](https://opencode.ai/docs/user-commands/) for more details details.
+See [User Commands Documentation](https://opencode.ai/docs/commands/) for more details details.
 
 ## 📸 Contextual Actions for Snapshots
 


### PR DESCRIPTION
https://opencode.ai/docs/user-commands/ goes to a 404 page.

I think it's supposed to be pointing to https://opencode.ai/docs/commands/