### PR TITLE
chore(timer): mark optional params as optional

### DIFF
--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -81,6 +81,9 @@ M.defaults = {
       preset = 'nerdfonts',
       overrides = {},
     },
+    loading_animation = {
+      frames = { '·', '․', '•', '∙', '●', '⬤', '●', '∙', '•', '․' },
+    },
     output = {
       tools = {
         show_output = true,

--- a/lua/opencode/types.lua
+++ b/lua/opencode/types.lua
@@ -102,6 +102,9 @@
 ---@class OpencodeCompletionConfig
 ---@field file_sources OpencodeCompletionFileSourcesConfig
 
+---@class OpencodeLoadingAnimationConfig
+---@field frames string[]
+
 ---@class OpencodeUIConfig
 ---@field position 'right'|'left' # Position of the UI (default: 'right')
 ---@field input_position 'bottom'|'top' # Position of the input window (default: 'bottom')
@@ -112,6 +115,7 @@
 ---@field display_cost boolean
 ---@field window_highlight string
 ---@field icons { preset: 'emoji'|'text'|'nerdfonts', overrides: table<string,string> }
+---@field loading_animation OpencodeLoadingAnimationConfig
 ---@field output { tools: { show_output: boolean } }
 ---@field input { text: { wrap: boolean } }
 ---@field completion OpencodeCompletionConfig

--- a/lua/opencode/ui/timer.lua
+++ b/lua/opencode/ui/timer.lua
@@ -1,9 +1,9 @@
 ---@class TimerOptions
 ---@field interval number The interval in milliseconds
 ---@field on_tick function The function to call on each tick
----@field on_stop function The function to call when the timer stops
----@field repeat_timer boolean Whether the timer should repeat (default: true)
----@field args table Optional arguments to pass to the on_tick function
+---@field on_stop? function The function to call when the timer stops
+---@field repeat_timer? boolean Whether the timer should repeat (default: true)
+---@field args? table Optional arguments to pass to the on_tick function
 
 local Timer = {}
 Timer.__index = Timer


### PR DESCRIPTION
I wanted to change the animation so I made it configurable

If you're open to considering a different default, I found this less distracting:

```lua
frames = { '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' },
```