### PR TITLE
feat: implement basic permissions worflow

### DIFF
--- a/lua/opencode/api_client.lua
+++ b/lua/opencode/api_client.lua
@@ -361,7 +361,14 @@ function OpencodeApiClient:subscribe_to_events(directory, on_event)
     url = url .. '?directory=' .. directory
   end
 
-  return server_job.stream_api(url, 'GET', nil, on_event)
+  return server_job.stream_api(url, 'GET', nil, function(chunk)
+    -- strip data: prefix if present
+    chunk = chunk:gsub('^data:%s*', '')
+    local ok, event = pcall(vim.json.decode, vim.trim(chunk))
+    if ok and event then
+      on_event(event)
+    end
+  end)
 end
 
 -- Tool endpoints

--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -46,6 +46,9 @@ M.defaults = {
       diff_restore_snapshot_all = '<leader>orR',
       open_configuration_file = '<leader>oC',
       swap_position = '<leader>ox', -- Swap Opencode pane left/right
+      permission_accept = '<leader>opa',
+      permission_accept_all = '<leader>opA',
+      permission_deny = '<leader>opd',
     },
     window = {
       submit = '<cr>',
@@ -66,6 +69,9 @@ M.defaults = {
       debug_message = '<leader>oD',
       debug_output = '<leader>oO',
       debug_session = '<leader>ods',
+      permission_accept = 'a',
+      permission_accept_all = 'A',
+      permission_deny = 'd',
     },
   },
   ui = {

--- a/lua/opencode/core.lua
+++ b/lua/opencode/core.lua
@@ -40,7 +40,6 @@ end
 function M.open(opts)
   opts = opts or { focus = 'input', new_session = false }
 
-  local state = require('opencode.state')
   if not state.opencode_server_job or not state.opencode_server_job:is_running() then
     state.opencode_server_job = server_job.ensure_server() --[[@as OpencodeServer]]
   end
@@ -239,7 +238,7 @@ end
 
 function M.setup()
   local OpencodeApiClient = require('opencode.api_client')
-  state.api_client = OpencodeApiClient.new() --[[@as OpencodeApiClient]]
+  state.api_client = OpencodeApiClient.new()
 end
 
 return M

--- a/lua/opencode/curl.lua
+++ b/lua/opencode/curl.lua
@@ -1,0 +1,154 @@
+local M = {}
+
+--- Build curl command arguments from options
+--- @param opts table Options for the curl request
+--- @return table args Array of curl command arguments
+local function build_curl_args(opts)
+  local args = { 'curl', '-s', '--no-buffer' }
+
+  if opts.method and opts.method ~= 'GET' then
+    table.insert(args, '-X')
+    table.insert(args, opts.method)
+  end
+
+  if opts.headers then
+    for key, value in pairs(opts.headers) do
+      table.insert(args, '-H')
+      table.insert(args, key .. ': ' .. value)
+    end
+  end
+
+  if opts.body then
+    table.insert(args, '-d')
+    table.insert(args, opts.body)
+  end
+
+  if opts.proxy and opts.proxy ~= '' then
+    table.insert(args, '--proxy')
+    table.insert(args, opts.proxy)
+  end
+
+  table.insert(args, opts.url)
+
+  return args
+end
+
+--- Parse HTTP response headers and body
+--- @param output string Raw curl output with headers
+--- @return table response Response object with status, headers, and body
+local function parse_response(output)
+  local lines = vim.split(output, '\n')
+  local status = 200
+  local headers = {}
+  local body_start = 1
+
+  -- Find status line and headers
+  for i, line in ipairs(lines) do
+    if line:match('^HTTP/') then
+      status = tonumber(line:match('HTTP/[%d%.]+%s+(%d+)')) or 200
+    elseif line:match('^[%w%-]+:') then
+      local key, value = line:match('^([%w%-]+):%s*(.*)$')
+      if key and value then
+        headers[key:lower()] = value
+      end
+    elseif line == '' then
+      body_start = i + 1
+      break
+    end
+  end
+
+  local body_lines = {}
+  for i = body_start, #lines do
+    table.insert(body_lines, lines[i])
+  end
+  local body = table.concat(body_lines, '\n')
+
+  return {
+    status = status,
+    headers = headers,
+    body = body,
+  }
+end
+
+--- Make an HTTP request
+--- @param opts table Request options
+--- @return table|nil job Job object for streaming requests, nil for regular requests
+function M.request(opts)
+  local args = build_curl_args(opts)
+
+  if opts.stream then
+    local buffer = ''
+
+    local job = vim.system(args, {
+      stdout = function(err, chunk)
+        if err then
+          if opts.on_error then
+            opts.on_error({ message = err })
+          end
+          return
+        end
+
+        if chunk then
+          buffer = buffer .. chunk
+
+          -- Extract complete lines
+          while buffer:find('\n') do
+            local line, rest = buffer:match('([^\n]*\n)(.*)')
+            if line then
+              opts.stream(nil, line)
+              buffer = rest
+            else
+              break
+            end
+          end
+        end
+      end,
+      stderr = function(err, data)
+        if err and opts.on_error then
+          opts.on_error({ message = err })
+        end
+      end,
+    }, opts.on_exit and function(result)
+      -- Flush any remaining buffer content
+      if buffer and buffer ~= '' then
+        opts.stream(nil, buffer)
+      end
+      opts.on_exit(result.code, result.signal)
+    end or nil)
+
+    return {
+      _job = job,
+      is_running = function()
+        return job and job.pid ~= nil
+      end,
+      shutdown = function()
+        if job and job.pid then
+          pcall(function()
+            job:kill('sigterm')
+          end)
+        end
+      end,
+    }
+  else
+    table.insert(args, 2, '-i')
+
+    vim.system(args, {
+      text = true,
+    }, function(result)
+      if result.code ~= 0 then
+        if opts.on_error then
+          opts.on_error({ message = result.stderr or 'curl failed' })
+        end
+        return
+      end
+
+      local response = parse_response(result.stdout or '')
+
+      if opts.callback then
+        opts.callback(response)
+      end
+    end)
+  end
+end
+
+return M

--- a/lua/opencode/event_manager.lua
+++ b/lua/opencode/event_manager.lua
@@ -1,0 +1,316 @@
+local state = require('opencode.state')
+
+--- @class EventInstallationUpdated
+--- @field type "installation.updated"
+--- @field properties {version: string}
+
+--- @class EventLspClientDiagnostics
+--- @field type "lsp.client.diagnostics"
+--- @field properties {serverID: string, path: string}
+
+--- @class EventMessageUpdated
+--- @field type "message.updated"
+--- @field properties {info: Message}
+
+--- @class EventMessageRemoved
+--- @field type "message.removed"
+--- @field properties {sessionID: string, messageID: string}
+
+--- @class EventMessagePartUpdated
+--- @field type "message.part.updated"
+--- @field properties {part: MessagePart}
+
+--- @class EventMessagePartRemoved
+--- @field type "message.part.removed"
+--- @field properties {sessionID: string, messageID: string, partID: string}
+
+--- @class EventSessionCompacted
+--- @field type "session.compacted"
+--- @field properties {sessionID: string}
+
+--- @class EventSessionIdle
+--- @field type "session.idle"
+--- @field properties {sessionID: string}
+
+--- @class EventSessionUpdated
+--- @field type "session.updated"
+--- @field properties {info: Session}
+
+--- @class EventSessionDeleted
+--- @field type "session.deleted"
+--- @field properties {info: Session}
+
+--- @class EventSessionError
+--- @field type "session.error"
+--- @field properties {sessionID: string, error: table}
+
+--- @class OpencodePermission
+--- @field id string
+--- @field type string
+--- @field pattern string|string[]
+--- @field sessionID string
+--- @field messageID string
+--- @field callID? string
+--- @field title string
+--- @field metadata table
+--- @field time {created: number}
+
+--- @class EventPermissionUpdated
+--- @field type "permission.updated"
+--- @field properties OpencodePermission
+
+--- @class EventPermissionReplied
+--- @field type "permission.replied"
+--- @field properties {sessionID: string, permissionID: string, response: string}
+
+--- @class EventFileEdited
+--- @field type "file.edited"
+--- @field properties {file: string}
+
+--- @class EventFileWatcherUpdated
+--- @field type "file.watcher.updated"
+--- @field properties {file: string, event: "add"|"change"|"unlink"}
+
+--- @class EventServerConnected
+--- @field type "server.connected"
+--- @field properties table
+
+--- @class EventIdeInstalled
+--- @field type "ide.installed"
+--- @field properties {ide: string}
+
+--- @class ServerStartingEvent
+--- @field server_job table
+
+--- @class ServerReadyEvent
+--- @field server_job table
+--- @field url string
+
+--- @class ServerStoppedEvent
+
+--- @alias EventName
+--- | "installation.updated"
+--- | "lsp.client.diagnostics"
+--- | "message.updated"
+--- | "message.removed"
+--- | "message.part.updated"
+--- | "message.part.removed"
+--- | "session.compacted"
+--- | "session.idle"
+--- | "session.updated"
+--- | "session.deleted"
+--- | "session.error"
+--- | "permission.updated"
+--- | "permission.replied"
+--- | "file.edited"
+--- | "file.watcher.updated"
+--- | "server.connected"
+--- | "ide.installed"
+--- | "server_starting"
+--- | "server_ready"
+--- | "server_stopped"
+
+--- @class EventManager
+--- @field events table<string, function[]> Event listener registry
+--- @field server_subscription table|nil Subscription to server events
+--- @field is_started boolean Whether the event manager is started
+local EventManager = {}
+EventManager.__index = EventManager
+
+--- Create a new EventManager instance
+--- @return EventManager
+function EventManager.new()
+  return setmetatable({
+    events = {},
+    server_subscription = nil,
+    is_started = false,
+  }, EventManager)
+end
+
+--- Subscribe to an event with type-safe callbacks using function overloads
+--- @overload fun(self: EventManager, event_name: "installation.updated", callback: fun(data: EventInstallationUpdated): nil)
+--- @overload fun(self: EventManager, event_name: "lsp.client.diagnostics", callback: fun(data: EventLspClientDiagnostics): nil)
+--- @overload fun(self: EventManager, event_name: "message.updated", callback: fun(data: EventMessageUpdated): nil)
+--- @overload fun(self: EventManager, event_name: "message.removed", callback: fun(data: EventMessageRemoved): nil)
+--- @overload fun(self: EventManager, event_name: "message.part.updated", callback: fun(data: EventMessagePartUpdated): nil)
+--- @overload fun(self: EventManager, event_name: "message.part.removed", callback: fun(data: EventMessagePartRemoved): nil)
+--- @overload fun(self: EventManager, event_name: "session.compacted", callback: fun(data: EventSessionCompacted): nil)
+--- @overload fun(self: EventManager, event_name: "session.idle", callback: fun(data: EventSessionIdle): nil)
+--- @overload fun(self: EventManager, event_name: "session.updated", callback: fun(data: EventSessionUpdated): nil)
+--- @overload fun(self: EventManager, event_name: "session.deleted", callback: fun(data: EventSessionDeleted): nil)
+--- @overload fun(self: EventManager, event_name: "session.error", callback: fun(data: EventSessionError): nil)
+--- @overload fun(self: EventManager, event_name: "permission.updated", callback: fun(data: EventPermissionUpdated): nil)
+--- @overload fun(self: EventManager, event_name: "permission.replied", callback: fun(data: EventPermissionReplied): nil)
+--- @overload fun(self: EventManager, event_name: "file.edited", callback: fun(data: EventFileEdited): nil)
+--- @overload fun(self: EventManager, event_name: "file.watcher.updated", callback: fun(data: EventFileWatcherUpdated): nil)
+--- @overload fun(self: EventManager, event_name: "server.connected", callback: fun(data: EventServerConnected): nil)
+--- @overload fun(self: EventManager, event_name: "ide.installed", callback: fun(data: EventIdeInstalled): nil)
+--- @overload fun(self: EventManager, event_name: "server_starting", callback: fun(data: ServerStartingEvent): nil)
+--- @overload fun(self: EventManager, event_name: "server_ready", callback: fun(data: ServerReadyEvent): nil)
+--- @overload fun(self: EventManager, event_name: "server_stopped", callback: fun(data: ServerStoppedEvent): nil)
+--- @param event_name EventName The event name to listen for
+--- @param callback function Callback function to execute when event is triggered
+function EventManager:subscribe(event_name, callback)
+  if not self.events[event_name] then
+    self.events[event_name] = {}
+  end
+  table.insert(self.events[event_name], callback)
+end
+
+--- Unsubscribe from an event with type-safe callbacks using function overloads
+--- @overload fun(self: EventManager, event_name: "installation.updated", callback: fun(data: EventInstallationUpdated): nil)
+--- @overload fun(self: EventManager, event_name: "lsp.client.diagnostics", callback: fun(data: EventLspClientDiagnostics): nil)
+--- @overload fun(self: EventManager, event_name: "message.updated", callback: fun(data: EventMessageUpdated): nil)
+--- @overload fun(self: EventManager, event_name: "message.removed", callback: fun(data: EventMessageRemoved): nil)
+--- @overload fun(self: EventManager, event_name: "message.part.updated", callback: fun(data: EventMessagePartUpdated): nil)
+--- @overload fun(self: EventManager, event_name: "message.part.removed", callback: fun(data: EventMessagePartRemoved): nil)
+--- @overload fun(self: EventManager, event_name: "session.compacted", callback: fun(data: EventSessionCompacted): nil)
+--- @overload fun(self: EventManager, event_name: "session.idle", callback: fun(data: EventSessionIdle): nil)
+--- @overload fun(self: EventManager, event_name: "session.updated", callback: fun(data: EventSessionUpdated): nil)
+--- @overload fun(self: EventManager, event_name: "session.deleted", callback: fun(data: EventSessionDeleted): nil)
+--- @overload fun(self: EventManager, event_name: "session.error", callback: fun(data: EventSessionError): nil)
+--- @overload fun(self: EventManager, event_name: "permission.updated", callback: fun(data: EventPermissionUpdated): nil)
+--- @overload fun(self: EventManager, event_name: "permission.replied", callback: fun(data: EventPermissionReplied): nil)
+--- @overload fun(self: EventManager, event_name: "file.edited", callback: fun(data: EventFileEdited): nil)
+--- @overload fun(self: EventManager, event_name: "file.watcher.updated", callback: fun(data: EventFileWatcherUpdated): nil)
+--- @overload fun(self: EventManager, event_name: "server.connected", callback: fun(data: EventServerConnected): nil)
+--- @overload fun(self: EventManager, event_name: "ide.installed", callback: fun(data: EventIdeInstalled): nil)
+--- @overload fun(self: EventManager, event_name: "server_starting", callback: fun(data: ServerStartingEvent): nil)
+--- @overload fun(self: EventManager, event_name: "server_ready", callback: fun(data: ServerReadyEvent): nil)
+--- @overload fun(self: EventManager, event_name: "server_stopped", callback: fun(data: ServerStoppedEvent): nil)
+--- @param event_name EventName The event name
+--- @param callback function The callback function to remove
+function EventManager:unsubscribe(event_name, callback)
+  local listeners = self.events[event_name]
+  if not listeners then
+    return
+  end
+
+  for i, cb in ipairs(listeners) do
+    if cb == callback then
+      table.remove(listeners, i)
+      break
+    end
+  end
+end
+
+--- Emit an event to all subscribers
+--- @param event_name EventName The event name
+--- @param data any Data to pass to event listeners
+function EventManager:emit(event_name, data)
+  local listeners = self.events[event_name]
+  if not listeners then
+    return
+  end
+
+  for _, callback in ipairs(listeners) do
+    pcall(callback, data)
+  end
+end
+
+--- Start the event manager and begin listening to server events
+function EventManager:start()
+  if self.is_started then
+    return
+  end
+
+  self.is_started = true
+
+  state.subscribe(
+    'opencode_server_job',
+    --- @param key string
+    --- @param current OpencodeServer|nil
+    --- @param prev OpencodeServer|nil
+    function(key, current, prev)
+      if current and current:get_spawn_promise() then
+        self:emit('server_starting', { server_job = current })
+
+        current:get_spawn_promise():and_then(function(server)
+          self:emit('server_ready', { server_job = server, url = server.url })
+          vim.defer_fn(function()
+            self:_subscribe_to_server_events(server)
+          end, 200)
+        end)
+
+        current:get_shutdown_promise():and_then(function()
+          self:emit('server_stopped', {})
+          self:_cleanup_server_subscription()
+        end)
+      elseif prev and not current then
+        self:emit('server_stopped', {})
+        self:_cleanup_server_subscription()
+      end
+    end
+  )
+end
+
+function EventManager:stop()
+  if not self.is_started then
+    return
+  end
+
+  self.is_started = false
+  self:_cleanup_server_subscription()
+
+  self.events = {}
+end
+
+--- Subscribe to server-sent events from the API
+--- @param server table The server instance
+function EventManager:_subscribe_to_server_events(server)
+  if not server.url then
+    return
+  end
+
+  self:_cleanup_server_subscription()
+
+  local api_client = state.api_client
+
+  self.server_subscription = api_client:subscribe_to_events(nil, function(event)
+    vim.schedule(function()
+      self:emit(event.type, event)
+    end)
+  end)
+end
+
+function EventManager:_cleanup_server_subscription()
+  if self.server_subscription then
+    pcall(function()
+      if self.server_subscription.shutdown then
+        self.server_subscription:shutdown()
+      elseif self.server_subscription.pid and type(self.server_subscription.pid) == 'number' then
+        vim.fn.jobstop(self.server_subscription.pid)
+      end
+    end)
+    self.server_subscription = nil
+  end
+end
+
+--- Get all event names that have subscribers
+--- @return string[] List of event names
+function EventManager:get_event_names()
+  local names = {}
+  for name, _ in pairs(self.events) do
+    table.insert(names, name)
+  end
+  return names
+end
+
+--- Get number of subscribers for an event
+--- @param event_name EventName The event name
+--- @return number Number of subscribers
+function EventManager:get_subscriber_count(event_name)
+  local listeners = self.events[event_name]
+  return listeners and #listeners or 0
+end
+
+function EventManager.setup()
+  state.event_manager = EventManager.new()
+  state.event_manager:start()
+
+  state.event_manager:subscribe('permission.updated', function(event_data)
+    state.current_permission = event_data.properties
+  end)
+end
+
+return EventManager

--- a/lua/opencode/init.lua
+++ b/lua/opencode/init.lua
@@ -12,8 +12,8 @@ function M.setup(opts)
     api.setup()
     keymap.setup(config.get('keymap'))
 
-    local completion = require('opencode.ui.completion')
-    completion.setup(config)
+    require('opencode.ui.completion').setup()
+    require('opencode.event_manager').setup()
   end)
 end
 

--- a/lua/opencode/opencode_server.lua
+++ b/lua/opencode/opencode_server.lua
@@ -62,9 +62,6 @@ end
 --- @param opts? OpencodeServerSpawnOpts
 --- @return Promise<OpencodeServer>
 function OpencodeServer:spawn(opts)
-  self.spawn_promise = Promise.new()
-  self.interrupt_promise = Promise.new()
-  self.shutdown_promise = Promise.new()
   opts = opts or {}
 
   self.job = vim.system({

--- a/lua/opencode/server_job.lua
+++ b/lua/opencode/server_job.lua
@@ -1,5 +1,5 @@
 local state = require('opencode.state')
-local curl = require('plenary.curl')
+local curl = require('opencode.curl')
 local Promise = require('opencode.promise')
 local opencode_server = require('opencode.opencode_server')
 
@@ -66,12 +66,8 @@ function M.stream_api(url, method, body, on_chunk)
   local opts = {
     url = url,
     method = method or 'GET',
-    headers = { ['Content-Type'] = 'application/json' },
     proxy = '',
     stream = function(err, chunk)
-      if chunk == nil or chunk == '' then
-        return
-      end
       on_chunk(chunk)
     end,
     on_error = function(err)

--- a/lua/opencode/state.lua
+++ b/lua/opencode/state.lua
@@ -26,11 +26,13 @@ local config = require('opencode.config').get()
 ---@field messages Message[]|nil
 ---@field current_message Message|nil
 ---@field last_user_message Message|nil
+---@field current_permission OpencodePermission|nil
 ---@field cost number
 ---@field tokens_count number
 ---@field job_count number
 ---@field opencode_server_job OpencodeServer|nil
 ---@field api_client OpencodeApiClient
+---@field event_manager EventManager|nil
 ---@field subscribe fun( key:string|nil, cb:fun(key:string, new_val:any, old_val:any))
 ---@field unsubscribe fun( key:string|nil, cb:fun(key:string, new_val:any, old_val:any))
 ---@field is_running fun():boolean
@@ -61,12 +63,14 @@ local _state = {
   messages = nil,
   current_message = nil,
   last_user_message = nil,
+  current_permission = nil,
   cost = 0,
   tokens_count = 0,
   -- job
   job_count = 0,
   opencode_server_job = nil,
   api_client = nil,
+  event_manager = nil,
 
   -- versions
   required_version = '0.6.3',

--- a/lua/opencode/types.lua
+++ b/lua/opencode/types.lua
@@ -70,6 +70,9 @@
 ---@field diff_restore_snapshot_all string
 ---@field open_configuration_file string
 ---@field swap_position string # Swap Opencode pane left/right
+---@field permission_accept string
+---@field permission_accept_all string
+---@field permission_deny string
 
 ---@class OpencodeKeymapWindow
 ---@field submit string
@@ -87,6 +90,13 @@
 ---@field switch_mode string
 ---@field focus_input string
 ---@field select_child_session string\n---@field debug_message string\n---@field debug_output string\n---@field debug_session string
+---@field debug_message string
+---@field debug_output string
+---@field debug_session string
+---@field permission_accept string
+---@field permission_accept_all string
+---@field permission_deny string
+
 ---@class OpencodeKeymap
 ---@field global OpencodeKeymapGlobal
 ---@field window OpencodeKeymapWindow

--- a/lua/opencode/ui/input_window.lua
+++ b/lua/opencode/ui/input_window.lua
@@ -225,6 +225,10 @@ function M.setup_autocmds(windows, group)
       M.refresh_placeholder(windows, input_lines)
     end,
   })
+
+  state.subscribe('current_permission', function()
+    require('opencode.keymap').toggle_permission_keymap(windows.input_buf)
+  end)
 end
 
 return M

--- a/lua/opencode/ui/output_window.lua
+++ b/lua/opencode/ui/output_window.lua
@@ -171,6 +171,10 @@ function M.setup_autocmds(windows, group)
       require('opencode.ui.input_window').refresh_placeholder(state.windows)
     end,
   })
+
+  state.subscribe('current_permission', function()
+    require('opencode.keymap').toggle_permission_keymap(windows.output_buf)
+  end)
 end
 
 function M.clear()

--- a/tests/unit/event_manager_spec.lua
+++ b/tests/unit/event_manager_spec.lua
@@ -1,0 +1,111 @@
+local EventManager = require('opencode.event_manager')
+
+describe('EventManager', function()
+  local event_manager
+
+  before_each(function()
+    event_manager = EventManager.new()
+  end)
+
+  after_each(function()
+    if event_manager then
+      event_manager:stop()
+    end
+  end)
+
+  it('should create a new instance', function()
+    assert.not_nil(event_manager)
+    assert.is_false(event_manager.is_started)
+    assert.are.same({}, event_manager.events)
+  end)
+
+  it('should subscribe and emit events', function()
+    local callback_called = false
+    local received_data = nil
+
+    event_manager:subscribe('test_event', function(data)
+      callback_called = true
+      received_data = data
+    end)
+
+    event_manager:emit('test_event', { test = 'data' })
+
+    assert.is_true(callback_called)
+    assert.are.same({ test = 'data' }, received_data)
+  end)
+
+  it('should handle multiple subscribers', function()
+    local callback1_called = false
+    local callback2_called = false
+
+    event_manager:subscribe('test_event', function(data)
+      callback1_called = true
+    end)
+
+    event_manager:subscribe('test_event', function(data)
+      callback2_called = true
+    end)
+
+    event_manager:emit('test_event', {})
+
+    assert.is_true(callback1_called)
+    assert.is_true(callback2_called)
+  end)
+
+  it('should unsubscribe correctly', function()
+    local callback_called = false
+    local callback = function(data)
+      callback_called = true
+    end
+
+    event_manager:subscribe('test_event', callback)
+    event_manager:unsubscribe('test_event', callback)
+    event_manager:emit('test_event', {})
+
+    assert.is_false(callback_called)
+  end)
+
+  it('should track subscriber count', function()
+    local callback1 = function() end
+    local callback2 = function() end
+
+    assert.are.equal(0, event_manager:get_subscriber_count('test_event'))
+
+    event_manager:subscribe('test_event', callback1)
+    assert.are.equal(1, event_manager:get_subscriber_count('test_event'))
+
+    event_manager:subscribe('test_event', callback2)
+    assert.are.equal(2, event_manager:get_subscriber_count('test_event'))
+
+    event_manager:unsubscribe('test_event', callback1)
+    assert.are.equal(1, event_manager:get_subscriber_count('test_event'))
+  end)
+
+  it('should list event names', function()
+    event_manager:subscribe('event1', function() end)
+    event_manager:subscribe('event2', function() end)
+
+    local names = event_manager:get_event_names()
+    table.sort(names)
+    assert.are.same({ 'event1', 'event2' }, names)
+  end)
+
+  it('should handle starting and stopping', function()
+    assert.is_false(event_manager.is_started)
+    
+    event_manager:start()
+    assert.is_true(event_manager.is_started)
+    
+    event_manager:stop()
+    assert.is_false(event_manager.is_started)
+    assert.are.same({}, event_manager.events)
+  end)
+
+  it('should not start multiple times', function()
+    event_manager:start()
+    local first_start = event_manager.is_started
+    
+    event_manager:start() -- Should not do anything
+    assert.are.equal(first_start, event_manager.is_started)
+  end)
+end)

--- a/tests/unit/server_job_spec.lua
+++ b/tests/unit/server_job_spec.lua
@@ -1,8 +1,7 @@
 local server_job = require('opencode.server_job')
-local Promise = require('opencode.promise')
 
--- We stub plenary.curl.request so we don't do real HTTP
-local curl = require('plenary.curl')
+local curl = require('opencode.curl')
+local assert = require('luassert')
 
 describe('server_job', function()
   local original_curl_request


### PR DESCRIPTION
This PR is adding permission workflow similar to the opencode one where you can accept, accept all or deny a tool request.

The prompt is not blocking the main nvim ui but rather just display a message in the chat window 

<img width="760" height="219" alt="Screenshot 2025-10-06 105302" src="https://github.com/user-attachments/assets/8ba7c2eb-c7a8-42b8-80eb-f828b647585d" />
<img width="755" height="192" alt="Screenshot 2025-10-06 105253" src="https://github.com/user-attachments/assets/596fd7b0-abbc-4aaf-b7ce-971556f7c4a5" />


This PR also replace plenary.curl because it was causing issues with the /event api where it was buffering some events and not sending them immediately (it was crucial for the the permission api) to have them ASAP.
