### PR TITLE
feat: add modes to keymap configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ require('opencode').setup({
   default_global_keymaps = true, -- If false, disables all default global keymaps
   default_mode = 'build', -- 'build' or 'plan' or any custom configured. @see [OpenCode Agents](https://opencode.ai/docs/modes/)
   keymap = {
+    -- Global keymaps (all use { 'n', 'v' } modes by default)
+    -- Can also use table format: toggle = { '<leader>og', { 'n', 'v' } }
     global = {
       toggle = '<leader>og', -- Open opencode. Close if opened
       open_input = '<leader>oi', -- Opens and focuses on input window on insert mode
@@ -118,23 +120,27 @@ require('opencode').setup({
       swap_position = '<leader>ox', -- Swap Opencode pane left/right
     },
     window = {
-      submit = '<cr>', -- Submit prompt (normal mode)
-      submit_insert = '<cr>', -- Submit prompt (insert mode)
-      close = '<esc>', -- Close UI windows
-      stop = '<C-c>', -- Stop opencode while it is running
-      next_message = ']]', -- Navigate to next message in the conversation
-      prev_message = '[[', -- Navigate to previous message in the conversation
-      mention = '@', -- Insert mention (file/agent)
-      mention_file = '~', -- Pick a file and add to context. See File Mentions section
-      slash_commands = '/', -- Pick a command to run in the input window
-      toggle_pane = '<tab>', -- Toggle between input and output panes
-      prev_prompt_history = '<up>', -- Navigate to previous prompt in history
-      next_prompt_history = '<down>', -- Navigate to next prompt in history
-      switch_mode = '<M-m>', -- Switch between modes (build/plan)
-      focus_input = '<C-i>', -- Focus on input window and enter insert mode at the end of the input from the output window
-      select_child_session = '<leader>oS', -- Select and load a child session
-      debug_message = '<leader>oD', -- Open raw message in new buffer for debugging
-      debug_output = '<leader>oO', -- Open raw output in new buffer for debugging
+      -- Window keymaps support multiple formats:
+      -- String format: submit = '<cr>' (uses default mode)
+      -- Named format: submit = { key = '<cr>', mode = 'n' }
+      -- Positional format: submit = { '<cr>', 'n' } (recommended for clarity)
+
+      submit = { '<cr>', { 'n', 'i' } }, -- Submit prompt (works in both normal and insert modes)
+      close = { '<esc>', 'n' }, -- Close UI windows
+      stop = { '<C-c>', 'n' }, -- Stop opencode while it is running
+      next_message = { ']]', 'n' }, -- Navigate to next message in the conversation
+      prev_message = { '[[', 'n' }, -- Navigate to previous message in the conversation
+      mention = { '@', 'i' }, -- Insert mention (file/agent)
+      mention_file = { '~', 'i' }, -- Pick a file and add to context. See File Mentions section
+      slash_commands = { '/', 'i' }, -- Pick a command to run in the input window
+      toggle_pane = { '<tab>', { 'n', 'i' } }, -- Toggle between input and output panes
+      prev_prompt_history = { '<up>', { 'n', 'i' } }, -- Navigate to previous prompt in history
+      next_prompt_history = { '<down>', { 'n', 'i' } }, -- Navigate to next prompt in history
+      switch_mode = { '<M-m>', { 'n', 'i' } }, -- Switch between modes (build/plan)
+      focus_input = { '<C-i>', 'n' }, -- Focus on input window and enter insert mode at the end of the input from the output window
+      select_child_session = { '<leader>oS', 'n' }, -- Select and load a child session
+      debug_message = { '<leader>oD', 'n' }, -- Open raw message in new buffer for debugging
+      debug_output = { '<leader>oO', 'n' }, -- Open raw output in new buffer for debugging
     },
   },
   ui = {
@@ -148,7 +154,7 @@ require('opencode').setup({
     window_highlight = 'Normal:OpencodeBackground,FloatBorder:OpencodeBorder', -- Highlight group for the opencode window
     icons = {
       preset = 'emoji', -- 'emoji' | 'text'. Choose UI icon style (default: 'emoji')
-      overrides = {},   -- Optional per-key overrides, see section below
+      overrides = {}, -- Optional per-key overrides, see section below
     },
     output = {
       tools = {

--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -25,6 +25,7 @@ M.defaults = {
   default_global_keymaps = true,
   default_mode = 'build',
   keymap = {
+    -- Global keymaps (all use { 'n', 'v' } modes by default)
     global = {
       toggle = '<leader>og',
       open_input = '<leader>oi',
@@ -48,24 +49,23 @@ M.defaults = {
       swap_position = '<leader>ox', -- Swap Opencode pane left/right
     },
     window = {
-      submit = '<cr>',
-      submit_insert = '<cr>',
-      close = '<esc>',
-      stop = '<C-c>',
-      next_message = ']]',
-      prev_message = '[[',
-      mention_file = '~',
-      mention = '@',
-      slash_commands = '/',
-      toggle_pane = '<tab>',
-      prev_prompt_history = '<up>',
-      next_prompt_history = '<down>',
-      switch_mode = '<M-m>',
-      focus_input = '<C-i>',
-      select_child_session = '<leader>oS',
-      debug_message = '<leader>oD',
-      debug_output = '<leader>oO',
-      debug_session = '<leader>ods',
+      submit = { '<cr>', { 'n', 'i' } }, -- Submit prompt (works in both normal and insert modes)
+      close = { '<esc>', 'n' },
+      stop = { '<C-c>', 'n' },
+      next_message = { ']]', 'n' },
+      prev_message = { '[[', 'n' },
+      mention_file = { '~', 'i' },
+      mention = { '@', 'i' },
+      slash_commands = { '/', 'i' },
+      toggle_pane = { '<tab>', { 'n', 'i' } },
+      prev_prompt_history = { '<up>', { 'n', 'i' } },
+      next_prompt_history = { '<down>', { 'n', 'i' } },
+      switch_mode = { '<M-m>', { 'n', 'i' } },
+      focus_input = { '<C-i>', 'n' },
+      select_child_session = { '<leader>oS', 'n' },
+      debug_message = { '<leader>oD', 'n' },
+      debug_output = { '<leader>oO', 'n' },
+      debug_session = { '<leader>ods', 'n' },
     },
   },
   ui = {
@@ -174,6 +174,27 @@ function M.setup(opts)
     else
       M.values[k] = v
     end
+  end
+
+  -- Handle backward compatibility for submit_insert
+  if M.values.keymap and M.values.keymap.window and M.values.keymap.window.submit_insert then
+    vim.notify(
+      'opencode.nvim: submit_insert keymap is deprecated. Use submit = { key, { "n", "i" } } instead.',
+      vim.log.levels.WARN
+    )
+    
+    -- If user has submit_insert but not submit, migrate submit_insert to submit with multi-mode
+    if not opts.keymap or not opts.keymap.window or not opts.keymap.window.submit then
+      local submit_insert_keymap = M.values.keymap.window.submit_insert
+      if type(submit_insert_keymap) == 'string' then
+        M.values.keymap.window.submit = { submit_insert_keymap, { 'n', 'i' } }
+      elseif type(submit_insert_keymap) == 'table' and submit_insert_keymap[1] then
+        M.values.keymap.window.submit = { submit_insert_keymap[1], { 'n', 'i' } }
+      end
+    end
+    
+    -- Remove submit_insert from final config
+    M.values.keymap.window.submit_insert = nil
   end
 end
 

--- a/lua/opencode/keymap.lua
+++ b/lua/opencode/keymap.lua
@@ -2,6 +2,75 @@ local api = require('opencode.api')
 
 local M = {}
 
+-- Default modes for window keymaps based on current hardcoded behavior
+local function get_default_window_modes(keymap_name)
+  local defaults = {
+    submit = 'n',
+    submit_insert = 'i',
+    mention = 'i',
+    slash_commands = 'i',
+    mention_file = 'i',
+    prev_prompt_history = { 'n', 'i' },
+    next_prompt_history = { 'n', 'i' },
+    switch_mode = { 'n', 'i' },
+    next_message = 'n',
+    prev_message = 'n',
+    close = 'n',
+    stop = 'n',
+    toggle_pane = { 'n', 'i' },
+    focus_input = 'n',
+    select_child_session = 'n',
+    debug_message = 'n',
+    debug_output = 'n',
+    debug_session = 'n',
+  }
+  return defaults[keymap_name] or 'n'
+end
+
+-- Default modes for global keymaps based on current hardcoded behavior
+local function get_default_global_modes(keymap_name)
+  -- All global keymaps currently use { 'n', 'v' } modes
+  return { 'n', 'v' }
+end
+
+-- Parse keymap value (string or table) and return key and mode
+---@param keymap_value string | { key: string, mode: string|string[] } | { [1]: string, [2]: string|string[] }
+---@param keymap_name string
+---@param default_modes_fn function
+---@return string key, string|string[] mode
+local function parse_keymap_value(keymap_value, keymap_name, default_modes_fn)
+  if type(keymap_value) == 'string' then
+    return keymap_value, default_modes_fn(keymap_name)
+  elseif type(keymap_value) == 'table' then
+    -- Support positional format: { '<key>', 'mode' }
+    if keymap_value[1] then
+      local key = keymap_value[1]
+      local mode = keymap_value[2] or default_modes_fn(keymap_name)
+      return key, mode
+    -- Support named format: { key = '<key>', mode = 'mode' }
+    elseif keymap_value.key then
+      return keymap_value.key, keymap_value.mode or default_modes_fn(keymap_name)
+    end
+  end
+  error('Invalid keymap value for ' .. keymap_name .. ': ' .. vim.inspect(keymap_value))
+end
+
+-- Parse a window keymap value using window-specific defaults
+---@param keymap_value OpencodeKeymapWindowValue
+---@param keymap_name string
+---@return string key, string|string[] mode
+function M.parse_window_keymap(keymap_value, keymap_name)
+  return parse_keymap_value(keymap_value, keymap_name, get_default_window_modes)
+end
+
+-- Parse a global keymap value using global-specific defaults
+---@param keymap_value OpencodeKeymapGlobalValue
+---@param keymap_name string
+---@return string key, string|string[] mode
+function M.parse_global_keymap(keymap_value, keymap_name)
+  return parse_keymap_value(keymap_value, keymap_name, get_default_global_modes)
+end
+
 -- Binds a keymap config with its api fn
 -- Name of api fn & keymap global config should always be the same
 ---@param keymap OpencodeKeymap The keymap configuration table
@@ -9,11 +78,13 @@ function M.setup(keymap)
   local cmds = api.commands
   local global = keymap.global
 
-  for key, mapping in pairs(global) do
-    if type(mapping) == 'string' then
-      vim.keymap.set({ 'n', 'v' }, mapping, function()
-        api[key]()
-      end, { silent = false, desc = cmds[key] and cmds[key].desc })
+  -- Process global keymaps using the new parsing approach
+  for keymap_name, keymap_value in pairs(global) do
+    if keymap_value then
+      local key, mode = M.parse_global_keymap(keymap_value, keymap_name)
+      vim.keymap.set(mode, key, function()
+        api[keymap_name]()
+      end, { silent = false, desc = cmds[keymap_name] and cmds[keymap_name].desc })
     end
   end
 end

--- a/lua/opencode/keymap.lua
+++ b/lua/opencode/keymap.lua
@@ -2,11 +2,11 @@ local api = require('opencode.api')
 
 local M = {}
 
--- Default modes for window keymaps based on current hardcoded behavior
-local function get_default_window_modes(keymap_name)
+-- Default modes for window keymaps (used for legacy configs that don't specify modes)
+local function get_legacy_window_modes(keymap_name)
   local defaults = {
-    submit = 'n',
-    submit_insert = 'i',
+    submit = { 'n', 'i' }, -- Now works in both normal and insert modes
+    submit_insert = 'i', -- Deprecated: kept for backward compatibility
     mention = 'i',
     slash_commands = 'i',
     mention_file = 'i',
@@ -60,7 +60,7 @@ end
 ---@param keymap_name string
 ---@return string key, string|string[] mode
 function M.parse_window_keymap(keymap_value, keymap_name)
-  return parse_keymap_value(keymap_value, keymap_name, get_default_window_modes)
+  return parse_keymap_value(keymap_value, keymap_name, get_legacy_window_modes)
 end
 
 -- Parse a global keymap value using global-specific defaults

--- a/lua/opencode/keymap.lua
+++ b/lua/opencode/keymap.lua
@@ -28,7 +28,7 @@ local function get_legacy_window_modes(keymap_name)
 end
 
 -- Default modes for global keymaps based on current hardcoded behavior
-local function get_default_global_modes(keymap_name)
+local function get_default_global_modes(_)
   -- All global keymaps currently use { 'n', 'v' } modes
   return { 'n', 'v' }
 end
@@ -69,6 +69,25 @@ end
 ---@return string key, string|string[] mode
 function M.parse_global_keymap(keymap_value, keymap_name)
   return parse_keymap_value(keymap_value, keymap_name, get_default_global_modes)
+end
+
+-- Extract just the key portion from a keymap configuration (for display purposes)
+---@param keymap_value string | { key: string, mode: string|string[] } | { [1]: string, [2]: string|string[] }
+---@return string key The key binding string, or '?' if invalid
+function M.extract_key(keymap_value)
+  -- Use a dummy default mode function since we only care about the key
+  local function dummy_default_modes()
+    return 'n'
+  end
+
+  -- Try to parse using the standard parsing logic
+  local success, key, _ = pcall(parse_keymap_value, keymap_value, 'unknown', dummy_default_modes)
+
+  if success then
+    return key
+  else
+    return '?' -- Fallback for invalid keymap values
+  end
 end
 
 -- Binds a keymap config with its api fn

--- a/lua/opencode/types.lua
+++ b/lua/opencode/types.lua
@@ -75,8 +75,7 @@
 ---@field swap_position OpencodeKeymapGlobalValue # Swap Opencode pane left/right
 
 ---@class OpencodeKeymapWindow
----@field submit OpencodeKeymapWindowValue
----@field submit_insert OpencodeKeymapWindowValue
+---@field submit OpencodeKeymapWindowValue # Submit prompt (works in both normal and insert modes)
 ---@field close OpencodeKeymapWindowValue
 ---@field stop OpencodeKeymapWindowValue
 ---@field next_message OpencodeKeymapWindowValue

--- a/lua/opencode/types.lua
+++ b/lua/opencode/types.lua
@@ -49,44 +49,50 @@
 ---@field workplace_slug string
 ---@field revert? SessionRevertInfo
 
+---@alias OpencodeKeymapGlobalValue string | { key: string, mode: string|string[] } | { [1]: string, [2]: string|string[] }
+---@alias OpencodeKeymapWindowValue string | { key: string, mode: string|string[] } | { [1]: string, [2]: string|string[] }
+
 ---@class OpencodeKeymapGlobal
----@field toggle string
----@field open_input string
----@field open_input_new_session string
----@field open_output string
----@field toggle_focus string
----@field close string
----@field select_session string
----@field configure_provider string
----@field diff_open string
----@field diff_next string
----@field diff_prev string
----@field diff_close string
----@field diff_revert_all_last_prompt string
----@field diff_revert_this_last_prompt string
----@field diff_revert_all string
----@field diff_revert_this string
----@field diff_restore_snapshot_file string
----@field diff_restore_snapshot_all string
----@field open_configuration_file string
----@field swap_position string # Swap Opencode pane left/right
+---@field toggle OpencodeKeymapGlobalValue
+---@field open_input OpencodeKeymapGlobalValue
+---@field open_input_new_session OpencodeKeymapGlobalValue
+---@field open_output OpencodeKeymapGlobalValue
+---@field toggle_focus OpencodeKeymapGlobalValue
+---@field close OpencodeKeymapGlobalValue
+---@field select_session OpencodeKeymapGlobalValue
+---@field configure_provider OpencodeKeymapGlobalValue
+---@field diff_open OpencodeKeymapGlobalValue
+---@field diff_next OpencodeKeymapGlobalValue
+---@field diff_prev OpencodeKeymapGlobalValue
+---@field diff_close OpencodeKeymapGlobalValue
+---@field diff_revert_all_last_prompt OpencodeKeymapGlobalValue
+---@field diff_revert_this_last_prompt OpencodeKeymapGlobalValue
+---@field diff_revert_all OpencodeKeymapGlobalValue
+---@field diff_revert_this OpencodeKeymapGlobalValue
+---@field diff_restore_snapshot_file OpencodeKeymapGlobalValue
+---@field diff_restore_snapshot_all OpencodeKeymapGlobalValue
+---@field open_configuration_file OpencodeKeymapGlobalValue
+---@field swap_position OpencodeKeymapGlobalValue # Swap Opencode pane left/right
 
 ---@class OpencodeKeymapWindow
----@field submit string
----@field submit_insert string
----@field close string
----@field stop string
----@field next_message string
----@field prev_message string
----@field mention_file string # mention files with a file picker
----@field mention string # mention subagents or files with a completion popup
----@field slash_commands string
----@field toggle_pane string
----@field prev_prompt_history string
----@field next_prompt_history string
----@field switch_mode string
----@field focus_input string
----@field select_child_session string\n---@field debug_message string\n---@field debug_output string\n---@field debug_session string
+---@field submit OpencodeKeymapWindowValue
+---@field submit_insert OpencodeKeymapWindowValue
+---@field close OpencodeKeymapWindowValue
+---@field stop OpencodeKeymapWindowValue
+---@field next_message OpencodeKeymapWindowValue
+---@field prev_message OpencodeKeymapWindowValue
+---@field mention_file OpencodeKeymapWindowValue # mention files with a file picker
+---@field mention OpencodeKeymapWindowValue # mention subagents or files with a completion popup
+---@field slash_commands OpencodeKeymapWindowValue
+---@field toggle_pane OpencodeKeymapWindowValue
+---@field prev_prompt_history OpencodeKeymapWindowValue
+---@field next_prompt_history OpencodeKeymapWindowValue
+---@field switch_mode OpencodeKeymapWindowValue
+---@field focus_input OpencodeKeymapWindowValue
+---@field select_child_session OpencodeKeymapWindowValue
+---@field debug_message OpencodeKeymapWindowValue
+---@field debug_output OpencodeKeymapWindowValue
+---@field debug_session OpencodeKeymapWindowValue
 ---@class OpencodeKeymap
 ---@field global OpencodeKeymapGlobal
 ---@field window OpencodeKeymapWindow

--- a/lua/opencode/ui/completion/commands.lua
+++ b/lua/opencode/ui/completion/commands.lua
@@ -24,13 +24,14 @@ local command_source = {
   priority = 1,
   complete = function(context)
     local config = require('opencode.config').get()
+    local keymap = require('opencode.keymap')
     local input_text = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 
     if not context.line:match('^' .. vim.pesc(context.trigger_char) .. '[^%s/]*$') then
       return {}
     end
 
-    if context.trigger_char ~= config.keymap.window.slash_commands then
+    if context.trigger_char ~= keymap.extract_key(config.keymap.window.slash_commands) then
       return {}
     end
 

--- a/lua/opencode/ui/completion/engines/blink_cmp.lua
+++ b/lua/opencode/ui/completion/engines/blink_cmp.lua
@@ -10,7 +10,8 @@ end
 
 function Source:get_trigger_characters()
   local config = require('opencode.config').get()
-  return { config.keymap.window.mention, config.keymap.window.slash_commands }
+  local keymap = require('opencode.keymap')
+  return { keymap.extract_key(config.keymap.window.mention), keymap.extract_key(config.keymap.window.slash_commands) }
 end
 
 function Source:is_available()

--- a/lua/opencode/ui/completion/engines/nvim_cmp.lua
+++ b/lua/opencode/ui/completion/engines/nvim_cmp.lua
@@ -13,7 +13,8 @@ function M.setup(completion_sources)
 
   function source:get_trigger_characters()
     local config = require('opencode.config').get()
-    return { config.keymap.window.mention, config.keymap.window.slash_commands }
+    local keymap = require('opencode.keymap')
+    return { keymap.extract_key(config.keymap.window.mention), keymap.extract_key(config.keymap.window.slash_commands) }
   end
 
   function source:is_available()

--- a/lua/opencode/ui/completion/engines/vim_complete.lua
+++ b/lua/opencode/ui/completion/engines/vim_complete.lua
@@ -28,8 +28,9 @@ end
 
 function M._get_trigger(before_cursor)
   local config = require('opencode.config').get()
+  local keymap = require('opencode.keymap')
   local trigger_chars =
-    table.concat(vim.tbl_map(vim.pesc, { config.keymap.window.mention, config.keymap.window.slash_commands }), '')
+    table.concat(vim.tbl_map(vim.pesc, { keymap.extract_key(config.keymap.window.mention), keymap.extract_key(config.keymap.window.slash_commands) }), '')
   local trigger_char, trigger_match = before_cursor:match('.*([' .. trigger_chars .. '])([%w_%-%.]*)')
   return trigger_char, trigger_match
 end

--- a/lua/opencode/ui/completion/files.lua
+++ b/lua/opencode/ui/completion/files.lua
@@ -100,7 +100,8 @@ local file_source = {
     local file_config = config.ui.completion.file_sources
     local input = context.input or ''
 
-    if not file_config.enabled or context.trigger_char ~= config.keymap.window.mention then
+    local keymap = require('opencode.keymap')
+    if not file_config.enabled or context.trigger_char ~= keymap.extract_key(config.keymap.window.mention) then
       return {}
     end
 

--- a/lua/opencode/ui/completion/subagents.lua
+++ b/lua/opencode/ui/completion/subagents.lua
@@ -6,7 +6,8 @@ local subagent_source = {
   complete = function(context)
     local subagents = require('opencode.config_file').get_subagents()
     local config = require('opencode.config').get()
-    if context.trigger_char ~= config.keymap.window.mention then
+    local keymap = require('opencode.keymap')
+    if context.trigger_char ~= keymap.extract_key(config.keymap.window.mention) then
       return {}
     end
 

--- a/lua/opencode/ui/input_window.lua
+++ b/lua/opencode/ui/input_window.lua
@@ -182,8 +182,7 @@ function M.setup_keymaps(windows)
 
   -- Define keymap handlers table - functions that need the parsed key get it via closure
   local keymap_handlers = {
-    submit = M.handle_submit,
-    submit_insert = M.handle_submit,
+    submit = M.handle_submit, -- Now handles both normal and insert modes
     mention_file = core.add_file_to_context,
     switch_mode = api.switch_to_next_mode,
     next_message = nav.goto_next_message,

--- a/lua/opencode/ui/input_window.lua
+++ b/lua/opencode/ui/input_window.lua
@@ -107,14 +107,21 @@ function M.refresh_placeholder(windows, input_lines)
     local win_width = vim.api.nvim_win_get_width(windows.input_win)
     local padding = string.rep(' ', win_width)
     local keys = config.keymap.window
+
+    -- Extract the actual key strings from keymap configurations
+    local keymap = require('opencode.keymap')
+    local slash_key = keymap.extract_key(keys.slash_commands)
+    local mention_key = keymap.extract_key(keys.mention)
+    local mention_file_key = keymap.extract_key(keys.mention_file)
+
     vim.api.nvim_buf_set_extmark(windows.input_buf, ns_id, 0, 0, {
       virt_text = {
         { 'Type your prompt here... ', 'OpenCodeHint' },
-        { keys.slash_commands, 'OpencodeInputLegend' },
+        { slash_key, 'OpencodeInputLegend' },
         { ' commands ', 'OpenCodeHint' },
-        { keys.mention, 'OpencodeInputLegend' },
+        { mention_key, 'OpencodeInputLegend' },
         { ' mentions ', 'OpenCodeHint' },
-        { keys.mention_file, 'OpencodeInputLegend' },
+        { mention_file_key, 'OpencodeInputLegend' },
         { ' to pick files' .. padding, 'OpenCodeHint' },
       },
 
@@ -203,10 +210,18 @@ function M.setup_keymaps(windows)
 
   -- Handle keymaps that need the parsed key as parameter
   local special_keymaps = {
-    mention = function(key) return completion.trigger_completion(key) end,
-    slash_commands = function(key) return completion.trigger_completion(key) end,
-    prev_prompt_history = function(key) return nav_history(key, 'prev') end,
-    next_prompt_history = function(key) return nav_history(key, 'next') end,
+    mention = function(key)
+      return completion.trigger_completion(key)
+    end,
+    slash_commands = function(key)
+      return completion.trigger_completion(key)
+    end,
+    prev_prompt_history = function(key)
+      return nav_history(key, 'prev')
+    end,
+    next_prompt_history = function(key)
+      return nav_history(key, 'next')
+    end,
   }
 
   for keymap_name, handler_factory in pairs(special_keymaps) do

--- a/lua/opencode/ui/output_window.lua
+++ b/lua/opencode/ui/output_window.lua
@@ -113,40 +113,50 @@ end
 
 function M.setup_keymaps(windows)
   local ui = require('opencode.ui.ui')
+  local keymap_mod = require('opencode.keymap')
   local api = require('opencode.api')
-  local map = require('opencode.keymap').buf_keymap
+  local map = keymap_mod.buf_keymap
   local nav = require('opencode.ui.navigation')
 
   local keymaps = config.keymap.window
   local output_buf = windows.output_buf
 
-  map(keymaps.close, api.close, output_buf, 'n')
+  -- Define keymap handlers table
+  local keymap_handlers = {
+    close = api.close,
+    next_message = nav.goto_next_message,
+    prev_message = nav.goto_prev_message,
+    stop = api.stop,
+    toggle_pane = api.toggle_pane,
+    focus_input = function()
+      ui.focus_input({ restore_position = true, start_insert = true })
+    end,
+    switch_mode = api.switch_to_next_mode,
+    select_child_session = api.select_child_session,
+  }
 
-  map(keymaps.next_message, nav.goto_next_message, output_buf, 'n')
-  map(keymaps.prev_message, nav.goto_prev_message, output_buf, 'n')
+  -- Apply keymaps from table
+  for keymap_name, handler in pairs(keymap_handlers) do
+    if keymaps[keymap_name] then
+      local key, mode = keymap_mod.parse_window_keymap(keymaps[keymap_name], keymap_name)
+      map(key, handler, output_buf, mode)
+    end
+  end
 
-  map(keymaps.stop, api.stop, output_buf, { 'n' })
-
-  map(keymaps.toggle_pane, api.toggle_pane, output_buf, { 'n' })
-
-  map(keymaps.focus_input, function()
-    ui.focus_input({ restore_position = true, start_insert = true })
-  end, output_buf, 'n')
-
-  map(keymaps.switch_mode, api.switch_to_next_mode, output_buf, 'n')
-
-  map(keymaps.select_child_session, api.select_child_session, output_buf, 'n')
-
+  -- Handle debug keymaps separately due to conditional loading and nil checks
   if config.debug.enabled then
     local debug_helper = require('opencode.ui.debug_helper')
-    if debug_helper.debug_output then
-      map(keymaps.debug_output, debug_helper.debug_output, output_buf, 'n')
-    end
-    if debug_helper.debug_message then
-      map(keymaps.debug_message, debug_helper.debug_message, output_buf, 'n')
-    end
-    if debug_helper.debug_session then
-      map(keymaps.debug_session, debug_helper.debug_session, output_buf, 'n')
+    local debug_keymaps = {
+      debug_output = debug_helper.debug_output,
+      debug_message = debug_helper.debug_message,
+      debug_session = debug_helper.debug_session,
+    }
+
+    for keymap_name, handler in pairs(debug_keymaps) do
+      if keymaps[keymap_name] and handler then
+        local key, mode = keymap_mod.parse_window_keymap(keymaps[keymap_name], keymap_name)
+        map(key, handler, output_buf, mode)
+      end
     end
   end
 end

--- a/tests/unit/keymap_spec.lua
+++ b/tests/unit/keymap_spec.lua
@@ -155,7 +155,7 @@ describe('opencode.keymap', function()
     it('parses string values with default modes', function()
       local key, mode = keymap.parse_window_keymap('<cr>', 'submit')
       assert.equal('<cr>', key)
-      assert.equal('n', mode) -- submit defaults to 'n'
+      assert.same({'n', 'i'}, mode) -- submit defaults to {'n', 'i'}
     end)
 
     it('parses string values with correct default modes for different keymaps', function()


### PR DESCRIPTION
I was overriding input/output buffer local keymaps (particularly `next/prev_prompt_history` and `toggle_pane`)  using Filetype autocmds and figured it was probably better to just make them configurable.

Should be backwards compatible.