### PR TITLE
feat(config): modern keymap format + mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,48 +99,53 @@ require('opencode').setup({
   default_mode = 'build', -- 'build' or 'plan' or any custom configured. @see [OpenCode Agents](https://opencode.ai/docs/modes/)
   keymap = {
     global = {
-      toggle = '<leader>og', -- Open opencode. Close if opened
-      open_input = '<leader>oi', -- Opens and focuses on input window on insert mode
-      open_input_new_session = '<leader>oI', -- Opens and focuses on input window on insert mode. Creates a new session
-      open_output = '<leader>oo', -- Opens and focuses on output window
-      toggle_focus = '<leader>ot', -- Toggle focus between opencode and last window
-      close = '<leader>oq', -- Close UI windows
-      select_session = '<leader>os', -- Select and load a opencode session
-      configure_provider = '<leader>op', -- Quick provider and model switch from predefined list
-      diff_open = '<leader>od', -- Opens a diff tab of a modified file since the last opencode prompt
-      diff_next = '<leader>o]', -- Navigate to next file diff
-      diff_prev = '<leader>o[', -- Navigate to previous file diff
-      diff_close = '<leader>oc', -- Close diff view tab and return to normal editing
-      diff_revert_all_last_prompt = '<leader>ora', -- Revert all file changes since the last opencode prompt
-      diff_revert_this_last_prompt = '<leader>ort', -- Revert current file changes since the last opencode prompt
-      diff_revert_all = '<leader>orA', -- Revert all file changes since the last opencode session
-      diff_revert_this = '<leader>orT', -- Revert current file changes since the last opencode session
-      swap_position = '<leader>ox', -- Swap Opencode pane left/right
-      permission_accept = '<leader>opa',  -- Accept permission request once
-      permission_accept_all = '<leader>opA', -- Accept all (for current tool)
-      permission_deny = '<leader>opd',-- Accept permission request once
+      ['<leader>og'] = 'toggle', -- Open opencode. Close if opened
+      ['<leader>oi'] = 'open_input', -- Opens and focuses on input window on insert mode
+      ['<leader>oI'] = 'open_input_new_session', -- Opens and focuses on input window on insert mode. Creates a new session
+      ['<leader>oo'] = 'open_output', -- Opens and focuses on output window
+      ['<leader>ot'] = 'toggle_focus', -- Toggle focus between opencode and last window
+      ['<leader>oq'] = 'close', -- Close UI windows
+      ['<leader>os'] = 'select_session', -- Select and load a opencode session
+      ['<leader>op'] = 'configure_provider', -- Quick provider and model switch from predefined list
+      ['<leader>od'] = 'diff_open', -- Opens a diff tab of a modified file since the last opencode prompt
+      ['<leader>o]'] = 'diff_next', -- Navigate to next file diff
+      ['<leader>o['] = 'diff_prev', -- Navigate to previous file diff
+      ['<leader>oc'] = 'diff_close', -- Close diff view tab and return to normal editing
+      ['<leader>ora'] = 'diff_revert_all_last_prompt', -- Revert all file changes since the last opencode prompt
+      ['<leader>ort'] = 'diff_revert_this_last_prompt', -- Revert current file changes since the last opencode prompt
+      ['<leader>orA'] = 'diff_revert_all', -- Revert all file changes since the last opencode session
+      ['<leader>orT'] = 'diff_revert_this', -- Revert current file changes since the last opencode session
+      ['<leader>orr'] = 'diff_restore_snapshot_file', -- Restore a file to a restore point
+      ['<leader>orR'] = 'diff_restore_snapshot_all', -- Restore all files to a restore point
+      ['<leader>oC'] = 'open_configuration_file', -- Open configuration file
+      ['<leader>ox'] = 'swap_position', -- Swap Opencode pane left/right
+      ['<leader>opa'] = 'permission_accept', -- Accept permission request once
+      ['<leader>opA'] = 'permission_accept_all', -- Accept all (for current tool)
+      ['<leader>opd'] = 'permission_deny', -- Deny permission request once
     },
     window = {
-      submit = '<cr>', -- Submit prompt (normal mode)
-      submit_insert = '<cr>', -- Submit prompt (insert mode)
-      close = '<esc>', -- Close UI windows
-      stop = '<C-c>', -- Stop opencode while it is running
-      next_message = ']]', -- Navigate to next message in the conversation
-      prev_message = '[[', -- Navigate to previous message in the conversation
-      mention = '@', -- Insert mention (file/agent)
-      mention_file = '~', -- Pick a file and add to context. See File Mentions section
-      slash_commands = '/', -- Pick a command to run in the input window
-      toggle_pane = '<tab>', -- Toggle between input and output panes
-      prev_prompt_history = '<up>', -- Navigate to previous prompt in history
-      next_prompt_history = '<down>', -- Navigate to next prompt in history
-      switch_mode = '<M-m>', -- Switch between modes (build/plan)
-      focus_input = '<C-i>', -- Focus on input window and enter insert mode at the end of the input from the output window
-      select_child_session = '<leader>oS', -- Select and load a child session
-      debug_message = '<leader>oD', -- Open raw message in new buffer for debugging
-      debug_output = '<leader>oO', -- Open raw output in new buffer for debugging
-      permission_accept = 'a',  -- Accept permission request once (only available when there is a pending permission request)
-      permission_accept_all = 'A', -- Accept all (for current tool) permission request once (only available when there is a pending permission request)
-      permission_deny = 'd',-- Accept permission request once (only available when there is a pending permission request)
+      ['<cr>'] = { 'submit_input_prompt', mode = { 'n', 'i' } }, -- Submit prompt (normal mode and insert mode)
+      ['<esc>'] = 'close', -- Close UI windows
+      ['<C-c>'] = 'stop', -- Stop opencode while it is running
+      [']]'] = 'next_message', -- Navigate to next message in the conversation
+      ['[['] = 'prev_message', -- Navigate to previous message in the conversation
+      ['~'] = { 'mention_file', mode = 'i' }, -- Pick a file and add to context. See File Mentions section
+      ['@'] = { 'mention', mode = 'i' }, -- Insert mention (file/agent)
+      ['/'] = { 'slash_commands', mode = 'i' }, -- Pick a command to run in the input window
+      ['<tab>'] = { 'toggle_pane', mode = { 'n', 'i' } }, -- Toggle between input and output panes
+      ['<up>'] = { 'prev_prompt_history', mode = { 'n', 'i' } }, -- Navigate to previous prompt in history
+      ['<down>'] = { 'next_prompt_history', mode = { 'n', 'i' } }, -- Navigate to next prompt in history
+      ['<M-m>'] = 'switch_mode', -- Switch between modes (build/plan)
+      ['<C-i>'] = 'focus_input', -- Focus on input window and enter insert mode at the end of the input from the output window
+      ['<leader>oS'] = 'select_child_session', -- Select and load a child session
+      ['<leader>oD'] = 'debug_message', -- Open raw message in new buffer for debugging
+      ['<leader>oO'] = 'debug_output', -- Open raw output in new buffer for debugging
+      ['<leader>ods'] = 'debug_session', -- Open raw session in new buffer for debugging
+    },
+    permission = {
+      accept = 'a', -- Accept permission request once (only available when there is a pending permission request)
+      accept_all = 'A', -- Accept all (for current tool) permission request once (only available when there is a pending permission request)
+      deny = 'd', -- Deny permission request once (only available when there is a pending permission request)
     },
   },
   ui = {
@@ -154,7 +159,7 @@ require('opencode').setup({
     window_highlight = 'Normal:OpencodeBackground,FloatBorder:OpencodeBorder', -- Highlight group for the opencode window
     icons = {
       preset = 'emoji', -- 'emoji' | 'text'. Choose UI icon style (default: 'emoji')
-      overrides = {},   -- Optional per-key overrides, see section below
+      overrides = {}, -- Optional per-key overrides, see section below
     },
     output = {
       tools = {

--- a/lua/opencode/api.lua
+++ b/lua/opencode/api.lua
@@ -227,8 +227,8 @@ function M.next_history()
 end
 
 function M.prev_prompt_history()
-  local config = require('opencode.config').get()
-  local key = config.keymap.window.prev_prompt_history
+  local config = require('opencode.config')
+  local key = config.get_key_for_function('window', 'prev_prompt_history')
   if key ~= '<up>' then
     return M.prev_history()
   end
@@ -242,8 +242,8 @@ function M.prev_prompt_history()
 end
 
 function M.next_prompt_history()
-  local config = require('opencode.config').get()
-  local key = config.keymap.window.next_prompt_history
+  local config = require('opencode.config')
+  local key = config.get_key_for_function('window', 'next_prompt_history')
   if key ~= '<down>' then
     return M.next_history()
   end
@@ -280,15 +280,15 @@ function M.mention_file()
 end
 
 function M.mention()
-  local config = require('opencode.config').get()
-  local char = config.keymap.window.mention
+  local config = require('opencode.config')
+  local char = config.get_key_for_function('window', 'mention')
   ui.focus_input({ restore_position = true, start_insert = true })
   require('opencode.ui.completion').trigger_completion(char)()
 end
 
 function M.slash_commands()
-  local config = require('opencode.config').get()
-  local char = config.keymap.window.slash_commands
+  local config = require('opencode.config')
+  local char = config.get_key_for_function('window', 'slash_commands')
   ui.focus_input({ restore_position = true, start_insert = true })
   require('opencode.ui.completion').trigger_completion(char)()
 end

--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -46,6 +46,7 @@ M.defaults = {
       ['<leader>orT'] = 'diff_revert_this',
       ['<leader>orr'] = 'diff_restore_snapshot_file',
       ['<leader>orR'] = 'diff_restore_snapshot_all',
+      ['<leader>oC'] = 'open_configuration_file',
       ['<leader>ox'] = 'swap_position',
       ['<leader>opa'] = 'permission_accept',
       ['<leader>opA'] = 'permission_accept_all',

--- a/lua/opencode/keymap.lua
+++ b/lua/opencode/keymap.lua
@@ -76,21 +76,11 @@ function M.clear_permission_keymap(buf)
       return
     end
 
-    local accept_key = permission_config.accept
-    local accept_all_key = permission_config.accept_all
-    local deny_key = permission_config.deny
-
-    if accept_key then
-      vim.api.nvim_buf_del_keymap(buf, 'n', accept_key)
-      vim.api.nvim_buf_del_keymap(buf, 'i', accept_key)
-    end
-    if accept_all_key then
-      vim.api.nvim_buf_del_keymap(buf, 'n', accept_all_key)
-      vim.api.nvim_buf_del_keymap(buf, 'i', accept_all_key)
-    end
-    if deny_key then
-      vim.api.nvim_buf_del_keymap(buf, 'n', deny_key)
-      vim.api.nvim_buf_del_keymap(buf, 'i', deny_key)
+    for _, key in pairs(permission_config) do
+      if key then
+        vim.api.nvim_buf_del_keymap(buf, 'n', key)
+        vim.api.nvim_buf_del_keymap(buf, 'i', key)
+      end
     end
   end)
 end
@@ -109,18 +99,11 @@ function M.toggle_permission_keymap(buf)
       return
     end
 
-    local accept_key = permission_config.accept
-    local accept_all_key = permission_config.accept_all
-    local deny_key = permission_config.deny
-
-    if accept_key then
-      M.buf_keymap(accept_key, api.permission_accept, buf, { 'n', 'i' })
-    end
-    if accept_all_key then
-      M.buf_keymap(accept_all_key, api.permission_accept_all, buf, { 'n', 'i' })
-    end
-    if deny_key then
-      M.buf_keymap(deny_key, api.permission_deny, buf, { 'n', 'i' })
+    for action, key in pairs(permission_config) do
+      local api_func = api["permission_" .. action]
+      if key and api_func then
+        M.buf_keymap(key, api_func, buf, { 'n', 'i' })
+      end
     end
   else
     M.clear_permission_keymap(buf)

--- a/lua/opencode/keymap.lua
+++ b/lua/opencode/keymap.lua
@@ -6,7 +6,6 @@ local M = {}
 function M.setup(keymap)
   local api = require('opencode.api')
   local cmds = api.commands
-  local config = require('opencode.config')
   local global = keymap.global
 
   -- keymap.setup() expects the new format - config normalization should happen in config.setup()
@@ -100,7 +99,7 @@ function M.toggle_permission_keymap(buf)
     end
 
     for action, key in pairs(permission_config) do
-      local api_func = api["permission_" .. action]
+      local api_func = api['permission_' .. action]
       if key and api_func then
         M.buf_keymap(key, api_func, buf, { 'n', 'i' })
       end

--- a/lua/opencode/types.lua
+++ b/lua/opencode/types.lua
@@ -49,57 +49,72 @@
 ---@field workplace_slug string
 ---@field revert? SessionRevertInfo
 
----@class OpencodeKeymapGlobal
----@field toggle string
----@field open_input string
----@field open_input_new_session string
----@field open_output string
----@field toggle_focus string
----@field close string
----@field select_session string
----@field configure_provider string
----@field diff_open string
----@field diff_next string
----@field diff_prev string
----@field diff_close string
----@field diff_revert_all_last_prompt string
----@field diff_revert_this_last_prompt string
----@field diff_revert_all string
----@field diff_revert_this string
----@field diff_restore_snapshot_file string
----@field diff_restore_snapshot_all string
----@field open_configuration_file string
----@field swap_position string # Swap Opencode pane left/right
----@field permission_accept string
----@field permission_accept_all string
----@field permission_deny string
+---@class OpencodeKeymapEntry
+---@field [1] string # Function name
+---@field mode string|string[] # Mode(s) for the keymap
 
----@class OpencodeKeymapWindow
----@field submit string
----@field submit_insert string
----@field close string
----@field stop string
----@field next_message string
----@field prev_message string
----@field mention_file string # mention files with a file picker
----@field mention string # mention subagents or files with a completion popup
----@field slash_commands string
----@field toggle_pane string
----@field prev_prompt_history string
----@field next_prompt_history string
----@field switch_mode string
----@field focus_input string
----@field select_child_session string\n---@field debug_message string\n---@field debug_output string\n---@field debug_session string
----@field debug_message string
----@field debug_output string
----@field debug_session string
----@field permission_accept string
----@field permission_accept_all string
----@field permission_deny string
+---@deprecated Use OpencodeKeymapGlobal instead
+---@class OpencodeKeymapGlobalOld
+---@field toggle? string
+---@field open_input? string
+---@field open_input_new_session? string
+---@field open_output? string
+---@field toggle_focus? string
+---@field close? string
+---@field select_session? string
+---@field configure_provider? string
+---@field diff_open? string
+---@field diff_next? string
+---@field diff_prev? string
+---@field diff_close? string
+---@field diff_revert_all_last_prompt? string
+---@field diff_revert_this_last_prompt? string
+---@field diff_revert_all? string
+---@field diff_revert_this? string
+---@field diff_restore_snapshot_file? string
+---@field diff_restore_snapshot_all? string
+---@field open_configuration_file? string
+---@field swap_position? string # Swap Opencode pane left/right
+---@field permission_accept? string
+---@field permission_accept_all? string
+---@field permission_deny? string
+
+---@deprecated Use OpencodeKeymapWindow instead
+---@class OpencodeKeymapWindowOld
+---@field submit? string
+---@field submit_insert? string
+---@field close? string
+---@field stop? string
+---@field next_message? string
+---@field prev_message? string
+---@field mention_file? string # mention files with a file picker
+---@field mention? string # mention subagents or files with a completion popup
+---@field slash_commands? string
+---@field toggle_pane? string
+---@field prev_prompt_history? string
+---@field next_prompt_history? string
+---@field switch_mode? string
+---@field focus_input? string
+---@field select_child_session? string
+---@field debug_message? string
+---@field debug_output? string
+---@field debug_session? string
+---@field permission_accept? string
+---@field permission_accept_all? string
+---@field permission_deny? string
+
+---@class OpencodeKeymapGlobal : table<string, string|OpencodeKeymapEntry>
+---@class OpencodeKeymapWindow : table<string, string|OpencodeKeymapEntry>
+
+---@class OpencodeKeymapPermission
+---@field accept string
+---@field accept_all string
+---@field deny string
 
 ---@class OpencodeKeymap
----@field global OpencodeKeymapGlobal
----@field window OpencodeKeymapWindow
+---@field global OpencodeKeymapGlobal|OpencodeKeymapGlobalOld
+---@field window OpencodeKeymapWindow|OpencodeKeymapWindowOld
+---@field permission OpencodeKeymapPermission
 
 ---@class OpencodeCompletionFileSourcesConfig
 ---@field enabled boolean
@@ -177,6 +192,10 @@
 ---@overload fun(key: "providers"): OpencodeProviders
 ---@overload fun(key: "context"): OpencodeContextConfig
 ---@overload fun(key: "debug"): OpencodeDebugConfig
+---@field get fun(key?: string): any
+---@field get_key_for_function fun(scope: 'global'|'window', function_name: string): string|nil
+---@field normalize_keymap fun(keymap_config: table): table
+---@field is_old_format fun(keymap_config: table): boolean
 
 ---@class OpencodeConfig
 ---@field preferred_picker 'telescope' | 'fzf' | 'mini.pick' | 'snacks' | nil

--- a/lua/opencode/ui/completion/commands.lua
+++ b/lua/opencode/ui/completion/commands.lua
@@ -31,7 +31,9 @@ local command_source = {
       return {}
     end
 
-    if context.trigger_char ~= config.keymap.window.slash_commands then
+    local config_mod = require('opencode.config')
+    local expected_trigger = config_mod.get_key_for_function('window', 'slash_commands')
+    if context.trigger_char ~= expected_trigger then
       return {}
     end
 

--- a/lua/opencode/ui/completion/engines/blink_cmp.lua
+++ b/lua/opencode/ui/completion/engines/blink_cmp.lua
@@ -9,8 +9,13 @@ function Source.new()
 end
 
 function Source:get_trigger_characters()
-  local config = require('opencode.config').get()
-  return { config.keymap.window.mention, config.keymap.window.slash_commands }
+  local config = require('opencode.config')
+  local mention_key = config.get_key_for_function('window', 'mention')
+  local slash_key = config.get_key_for_function('window', 'slash_commands')
+  local triggers = {}
+  if mention_key then table.insert(triggers, mention_key) end
+  if slash_key then table.insert(triggers, slash_key) end
+  return triggers
 end
 
 function Source:is_available()

--- a/lua/opencode/ui/completion/engines/nvim_cmp.lua
+++ b/lua/opencode/ui/completion/engines/nvim_cmp.lua
@@ -12,8 +12,13 @@ function M.setup(completion_sources)
   end
 
   function source:get_trigger_characters()
-    local config = require('opencode.config').get()
-    return { config.keymap.window.mention, config.keymap.window.slash_commands }
+    local config = require('opencode.config')
+    local mention_key = config.get_key_for_function('window', 'mention')
+    local slash_key = config.get_key_for_function('window', 'slash_commands')
+    local triggers = {}
+    if mention_key then table.insert(triggers, mention_key) end
+    if slash_key then table.insert(triggers, slash_key) end
+    return triggers
   end
 
   function source:is_available()

--- a/lua/opencode/ui/completion/engines/vim_complete.lua
+++ b/lua/opencode/ui/completion/engines/vim_complete.lua
@@ -27,9 +27,13 @@ function M._fake_feed_key(trigger_char)
 end
 
 function M._get_trigger(before_cursor)
-  local config = require('opencode.config').get()
-  local trigger_chars =
-    table.concat(vim.tbl_map(vim.pesc, { config.keymap.window.mention, config.keymap.window.slash_commands }), '')
+  local config = require('opencode.config')
+  local mention_key = config.get_key_for_function('window', 'mention')
+  local slash_key = config.get_key_for_function('window', 'slash_commands')
+  local triggers = {}
+  if mention_key then table.insert(triggers, mention_key) end
+  if slash_key then table.insert(triggers, slash_key) end
+  local trigger_chars = table.concat(vim.tbl_map(vim.pesc, triggers), '')
   local trigger_char, trigger_match = before_cursor:match('.*([' .. trigger_chars .. '])([%w_%-%.]*)')
   return trigger_char, trigger_match
 end

--- a/lua/opencode/ui/completion/files.lua
+++ b/lua/opencode/ui/completion/files.lua
@@ -100,7 +100,9 @@ local file_source = {
     local file_config = config.ui.completion.file_sources
     local input = context.input or ''
 
-    if not file_config.enabled or context.trigger_char ~= config.keymap.window.mention then
+    local config_mod = require('opencode.config')
+    local expected_trigger = config_mod.get_key_for_function('window', 'mention')
+    if not file_config.enabled or context.trigger_char ~= expected_trigger then
       return {}
     end
 

--- a/lua/opencode/ui/completion/subagents.lua
+++ b/lua/opencode/ui/completion/subagents.lua
@@ -6,7 +6,9 @@ local subagent_source = {
   complete = function(context)
     local subagents = require('opencode.config_file').get_subagents()
     local config = require('opencode.config').get()
-    if context.trigger_char ~= config.keymap.window.mention then
+    local config_mod = require('opencode.config')
+    local expected_trigger = config_mod.get_key_for_function('window', 'mention')
+    if context.trigger_char ~= expected_trigger then
       return {}
     end
 

--- a/lua/opencode/ui/footer.lua
+++ b/lua/opencode/ui/footer.lua
@@ -19,7 +19,8 @@ function M.render(windows)
   end
 
   if state.is_running() then
-    local cancel_keymap = config.keymap.window.stop or '<C-c>'
+    local config_mod = require('opencode.config')
+    local cancel_keymap = config_mod.get_key_for_function('window', 'stop') or '<C-c>'
     local legend = string.format(' %s to cancel', cancel_keymap)
     append_to_footer(legend)
   end

--- a/lua/opencode/ui/output_window.lua
+++ b/lua/opencode/ui/output_window.lua
@@ -112,24 +112,31 @@ function M.close()
 end
 
 function M.setup_keymaps(windows)
-  local api = require('opencode.api')
   local map = require('opencode.keymap').buf_keymap
-
-  local keymaps = config.keymap.window
+  local api = require('opencode.api')
+  local config_mod = require('opencode.config')
   local output_buf = windows.output_buf
+  local window_keymaps = config_mod.get('keymap').window
 
-  map(keymaps.close, api.close, output_buf, 'n')
-  map(keymaps.next_message, api.next_message, output_buf, 'n')
-  map(keymaps.prev_message, api.prev_message, output_buf, 'n')
-  map(keymaps.stop, api.stop, output_buf, { 'n' })
-  map(keymaps.toggle_pane, api.toggle_pane, output_buf, { 'n' })
-  map(keymaps.focus_input, api.focus_input, output_buf, 'n')
-  map(keymaps.switch_mode, api.switch_mode, output_buf, 'n')
-  map(keymaps.select_child_session, api.select_child_session, output_buf, 'n')
+  for key, value in pairs(window_keymaps) do
+    if value ~= false then
+      local func_name, mode
 
-  map(keymaps.debug_output, api.debug_output, output_buf, 'n')
-  map(keymaps.debug_message, api.debug_message, output_buf, 'n')
-  map(keymaps.debug_session, api.debug_session, output_buf, 'n')
+      if type(value) == 'string' then
+        func_name = value
+        mode = 'n'
+      elseif type(value) == 'table' and value[1] then
+        func_name = value[1]
+        mode = value.mode or 'n'
+      end
+
+      if func_name then
+        if api[func_name] then
+          map(key, api[func_name], output_buf, mode)
+        end
+      end
+    end
+  end
 end
 
 function M.setup_autocmds(windows, group)

--- a/lua/opencode/ui/session_formatter.lua
+++ b/lua/opencode/ui/session_formatter.lua
@@ -97,9 +97,9 @@ function M._format_permission_request()
   M.output:add_line(
     string.format(
       '> Accept `%s`    Always `%s`    Deny `%s`',
-      config.keymap[scope].permission_accept,
-      config.keymap[scope].permission_accept_all,
-      config.keymap[scope].permission_deny
+      config.keymap.permission.accept,
+      config.keymap.permission.accept_all,
+      config.keymap.permission.deny
     )
   )
   M.output:add_empty_line()


### PR DESCRIPTION
Here's the updated PR to have global and window keymaps be key first.

I went back and forth on it, but I currently have window permissions split out into their own table and have them action first. (but if you want it the other way, I can change it so they're also key first).