### PR TITLE
refactor: carefully set model from session

### DIFF
--- a/lua/opencode/api.lua
+++ b/lua/opencode/api.lua
@@ -355,7 +355,7 @@ function M.initialize()
     vim.notify('Failed to create new session', vim.log.levels.ERROR)
     return
   end
-  if not state.current_model then
+  if not core.initialize_current_model() or not state.current_model then
     vim.notify('No model selected', vim.log.levels.ERROR)
     return
   end

--- a/lua/opencode/state.lua
+++ b/lua/opencode/state.lua
@@ -1,5 +1,3 @@
-local config = require('opencode.config')
-
 ---@class OpencodeWindowState
 ---@field input_win integer|nil
 ---@field output_win integer|nil

--- a/lua/opencode/ui/topbar.lua
+++ b/lua/opencode/ui/topbar.lua
@@ -1,3 +1,4 @@
+local config = require('opencode.config')
 local util = require('opencode.util')
 
 local M = {}
@@ -10,16 +11,10 @@ local LABELS = {
 }
 
 local function format_model_info()
-  if not state.current_model or state.current_model == '' then
-    local info = config_file.get_opencode_config()
-    state.current_model = info and info.model
-  end
-
-  local config = require('opencode.config')
   local parts = {}
 
-  if config.ui.display_model and state.current_model then
-    if state.current_model ~= '' then
+  if config.ui.display_model then
+    if state.current_model then
       table.insert(parts, state.current_model)
     end
   end


### PR DESCRIPTION
When loading a session, clear state.current_model and set it to the model used by the most recent message.

Topbar shouldn't set a model as a side effect, it should just display what's been selected.

Add `core.initialize_current_model()` which will initialize state.current_model to the default from the config_file if it hasn't been set

I think this achieves the behavior described in https://github.com/sudo-tee/opencode.nvim/pull/96#issuecomment-3487956371:

- If you load a session, it will set `state.current_model` to the model most recently used in that session
- If you create a new session, `state.current_model` will get re-initialized to the default
- Rerendering a session won't change `state.current_model`