### PR TITLE
fix(renderer): clear permissions when resetting

### DIFF
--- a/lua/opencode/ui/renderer.lua
+++ b/lua/opencode/ui/renderer.lua
@@ -46,7 +46,7 @@ function M.reset()
   state.messages = {}
   state.last_user_message = nil
 
-  if state.current_permission then
+  if state.current_permission and state.api_client then
     require('opencode.api').respond_to_permission('reject')
     state.current_permission = nil
   end


### PR DESCRIPTION
There currently isn't a way to fetch a pending permission so when we're resetting, reject any pending permissions.

Fixes #102