### PR TITLE
fix(telescope): AM/PM were being cut off

### DIFF
--- a/lua/opencode/ui/base_picker.lua
+++ b/lua/opencode/ui/base_picker.lua
@@ -105,7 +105,7 @@ local function telescope_ui(opts)
     finder = finders.new_table({ results = opts.items, entry_maker = make_entry }),
     sorter = conf.generic_sorter({}),
     layout_config = opts.width and {
-        width = opts.width + 4, -- extra space for telescope UI
+        width = opts.width + 7, -- extra space for telescope UI
       } or nil,
     attach_mappings = function(prompt_bufnr, map)
       actions.select_default:replace(function()


### PR DESCRIPTION
Tiny fix

before:

<img width="1240" height="1079" alt="Screenshot 2025-11-07 at 12 54 13" src="https://github.com/user-attachments/assets/dccd15f4-833d-4e0d-9811-6066638d0d32" />

after:

<img width="1259" height="1066" alt="Screenshot 2025-11-07 at 12 54 22" src="https://github.com/user-attachments/assets/814f2f0f-2b27-4a4a-9615-41142ae2d5d5" />
