### PR TITLE
refactor(renderer): clean up event subscriptions

### DIFF
--- a/lua/opencode/ui/ui.lua
+++ b/lua/opencode/ui/ui.lua
@@ -99,7 +99,7 @@ function M.create_windows()
   footer.setup(windows)
   topbar.setup()
 
-  renderer.setup_subscriptions(windows)
+  renderer.setup_subscriptions()
 
   autocmds.setup_autocmds(windows)
   autocmds.setup_resize_handler(windows)

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -26,11 +26,7 @@ function M.replay_setup()
   -- we use the event manager to dispatch events
   require('opencode.event_manager').setup()
 
-  -- we don't change any changes on session
-  renderer._cleanup_subscriptions()
-
-  -- but we do want event_manager subscriptions so set those back up
-  renderer._setup_event_subscriptions()
+  renderer.setup_subscriptions()
 
   renderer.reset()
 


### PR DESCRIPTION
Noticed that we already had a subscription to `state.active_session` and realized we could clean up the subscribes a bit.