### PR TITLE
test(replay): fix full session replay

### DIFF
--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -21,12 +21,11 @@ function M.replay_setup()
   end
 
   state.current_mode = 'build' -- default mode for tests
-  state.windows = ui.create_windows()
 
-  -- we use the event manager to dispatch events
+  -- we use the event manager to dispatch events, have to setup before ui.create_windows
   require('opencode.event_manager').setup()
 
-  renderer.setup_subscriptions()
+  state.windows = ui.create_windows()
 
   renderer.reset()
 

--- a/tests/manual/renderer_replay.lua
+++ b/tests/manual/renderer_replay.lua
@@ -196,13 +196,14 @@ function M.replay_full_session()
   end
 
   state.active_session = helpers.get_session_from_events(M.events, true)
-  local session_data = helpers.load_session_from_events(M.events)
+  vim.schedule(function()
+    local session_data = helpers.load_session_from_events(M.events)
 
-  renderer.reset()
-  renderer._render_full_session_data(session_data)
-  state.job_count = 0
+    renderer._render_full_session_data(session_data)
+    state.job_count = 0
 
-  vim.notify('Rendered full session from loaded events', vim.log.levels.INFO)
+    vim.notify('Rendered full session from loaded events', vim.log.levels.INFO)
+  end)
   return true
 end
 


### PR DESCRIPTION
The issue is a bit subtle: the event notification about the session changing from nil to an id gets wrapped in vim.schedule but that means it gets delivered after we've loaded the full session, which causes us to clear the whole session right after we just loaded it, leaving the output blank.

It's possible that we might want to not wrap state notifications in vim.schedule and expect listeners to handle cases where they can't be in a fast context. The primary benefit of that would be guaranteed ordering of events.

For example, in this case, the event that the session was set would've been processed before we loaded the session so the issue wouldn't exist.

The issue is only coming up now because the replay script used to unsubscribe to `state.active_session` changes but i didn't keep that because it felt like a hack.

For now, I think we can just watch out for any issues in actual usage.