### PR TITLE
Fix session picker

### DIFF
--- a/lua/opencode/ui/session_picker.lua
+++ b/lua/opencode/ui/session_picker.lua
@@ -2,7 +2,7 @@ local M = {}
 local config = require('opencode.config')
 local base_picker = require('opencode.ui.base_picker')
 local util = require('opencode.util')
-local api = require('lua.opencode.api')
+local api = require('opencode.api')
 
 ---Format session parts for session picker
 ---@param session Session object


### PR DESCRIPTION
This appears to be a regression introduced 2 days ago via https://github.com/sudo-tee/opencode.nvim/commit/d6721a7be815d35e09f4f62e6b7dd6fc71a4681a which added the broken import

```
Error executing vim.schedule lua callback: ...im/lazy/opencode.nvim/lua/opencode/ui/session_picker.lua:5: module 'lua.opencode.
api' not found:
        no field package.preload['lua.opencode.api']
        cache_loader: module 'lua.opencode.api' not found
        cache_loader_lib: module 'lua.opencode.api' not found
        no file '/nix/store/5nxkn4vpgfdyzwqp1l5s7wqczcsppkwa-luajit-2.1.1741730670-env/share/lua/5.1/lua/opencode/api.lua'
        no file '/nix/store/5nxkn4vpgfdyzwqp1l5s7wqczcsppkwa-luajit-2.1.1741730670-env/share/lua/5.1/lua/opencode/api/init.lua'

        no file '/nix/store/5nxkn4vpgfdyzwqp1l5s7wqczcsppkwa-luajit-2.1.1741730670-env/lib/lua/5.1/lua/opencode/api.so'
        no file '/Users/elsesiy/.local/share/nvim/lazy/blink.cmp/lua/blink/cmp/fuzzy/rust/../../../../../target/release/liblua/
opencode/api.dylib'
        no file '/Users/elsesiy/.local/share/nvim/lazy/blink.cmp/lua/blink/cmp/fuzzy/rust/../../../../../target/release/lua/ope
ncode/api.dylib'
        no file '/nix/store/5nxkn4vpgfdyzwqp1l5s7wqczcsppkwa-luajit-2.1.1741730670-env/lib/lua/5.1/lua.so'
        no file '/Users/elsesiy/.local/share/nvim/lazy/blink.cmp/lua/blink/cmp/fuzzy/rust/../../../../../target/release/liblua.
dylib'
        no file '/Users/elsesiy/.local/share/nvim/lazy/blink.cmp/lua/blink/cmp/fuzzy/rust/../../../../../target/release/lua.dyl
ib'
stack traceback:
        [C]: in function 'require'
        ...im/lazy/opencode.nvim/lua/opencode/ui/session_picker.lua:5: in main chunk
        [C]: in function 'require'
        ...cal/share/nvim/lazy/opencode.nvim/lua/opencode/ui/ui.lua:195: in function 'select_session'
        ...ocal/share/nvim/lazy/opencode.nvim/lua/opencode/core.lua:21: in function 'select_session'
        ...local/share/nvim/lazy/opencode.nvim/lua/opencode/api.lua:89: in function 'fn'
        ...zy/opencode.nvim/lua/opencode/ui/completion/commands.lua:80: in function ''
        vim/_editor.lua: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```