### PR TITLE
fix(session_picker): handle nil session after rename

### DIFF
--- a/lua/opencode/ui/session_picker.lua
+++ b/lua/opencode/ui/session_picker.lua
@@ -22,6 +22,10 @@ function M.pick(sessions, callback)
         api
           .rename_session(selected)
           :and_then(function(updated_session)
+            if not updated_session then
+              promise:resolve(nil)
+              return
+            end
             local idx = util.find_index_of(opts.items, function(item)
               return item.id == updated_session.id
             end)


### PR DESCRIPTION
- Add null check for updated_session result
- Resolve promise with nil if session rename fails
- Prevent index lookup on nil session object