### PR TITLE
fix(history): error when windows closed

### DIFF
--- a/lua/opencode/ui/history_picker.lua
+++ b/lua/opencode/ui/history_picker.lua
@@ -94,6 +94,7 @@ function M.pick(callback)
         local windows = state.windows
         if not input_window.mounted(windows) then
           require('opencode.core').open({ focus_input = true })
+          windows = state.windows
         end
         ---@cast windows { input_win: integer, input_buf: integer }
 


### PR DESCRIPTION
Handle the case when the history dialog is open and an item is selected before the input/output windows are created.

Fixes #141