### PR TITLE
fix: improve context clearing in new sessions and file mentions

### DIFF
--- a/lua/opencode/core.lua
+++ b/lua/opencode/core.lua
@@ -93,6 +93,7 @@ M.open = Promise.async(function(opts)
     if opts.new_session then
       state.active_session = nil
       state.last_sent_context = nil
+      context.unload_attachments()
 
       state.current_model = nil
       state.current_mode = nil


### PR DESCRIPTION
## Summary
- Clear attachments when starting a new session with `/new` command

## Fixes
1. **Context persisting across new sessions**: The `/new` command now calls `context.unload_attachments()` to clear mentioned files, selections, and linter errors when starting a new session


## Test plan
- [x] Run unit tests
- [x] Manually test `/new` command clears context