### PR TITLE
feat(ui): add auto_scroll config for output window

### DIFF
--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -124,6 +124,7 @@ M.defaults = {
         show_output = true,
         show_reasoning_output = true,
       },
+      auto_scroll = false,
       always_scroll_to_bottom = false,
     },
     input = {

--- a/lua/opencode/ui/output_window.lua
+++ b/lua/opencode/ui/output_window.lua
@@ -232,4 +232,12 @@ function M.clear()
   M.viewport_at_bottom = true
 end
 
+function M.should_auto_scroll()
+  if config.ui.output.always_scroll_to_bottom then
+    return true
+  end
+
+  return config.ui.output.auto_scroll ~= false
+end
+
 return M

--- a/lua/opencode/ui/renderer.lua
+++ b/lua/opencode/ui/renderer.lua
@@ -231,7 +231,12 @@ function M.scroll_to_bottom()
 
   trigger_on_data_rendered()
 
+  if not output_window.should_auto_scroll() then
+    return
+  end
+
   -- Determine if we should scroll to bottom
+
   local should_scroll = false
 
   -- Always scroll on initial render


### PR DESCRIPTION
Introduce a new `auto_scroll` option in the output window configuration. This allows users to control whether the output window should automatically scroll to the bottom when new content is rendered. The `always_scroll_to_bottom` option still takes precedence if enabled.