### PR TITLE
fix: respect user's default snacks picker layout preset

### DIFF
--- a/lua/opencode/ui/base_picker.lua
+++ b/lua/opencode/ui/base_picker.lua
@@ -436,6 +436,10 @@ local function snacks_picker_ui(opts)
   -- Add file preview if enabled
   if has_preview then
     snack_opts.preview = 'file'
+  else
+    snack_opts.preview = function()
+      return false
+    end
   end
 
   snack_opts.win = snack_opts.win or {}


### PR DESCRIPTION
## Summary
- Removes hardcoded layout preset from snacks picker in base_picker, allowing user-configured presets (ivy/telescope/default/select) to be respected for pickers
- Previously only the file_picker respected user defaults; this aligns base_picker behavior to match

### Fixes
- The Snacks `config` func doesn't have an expected return type
- The `title` from `PickerOption string|fun()` is converted to a `string?` which the Snacks picker exptects
- When no preview is available, we need to explicitly set the preview to `false` in Snacks to prevent errors when the global default config has preview enabled