### PR TITLE
fix: global keymaps config is not respected

### DIFF
--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -248,11 +248,11 @@ end
 function M.setup(opts)
   opts = opts or {}
 
+  M.values = vim.tbl_deep_extend('force', M.values, opts --[[@as OpencodeConfig]])
+
   if opts.default_global_keymaps == false then
     M.values.keymap.editor = {}
   end
-
-  M.values = vim.tbl_deep_extend('force', M.values, opts --[[@as OpencodeConfig]])
 
   update_keymap_prefix(M.values.keymap_prefix, M.defaults.keymap_prefix)
 end


### PR DESCRIPTION
It seems to me that global_keymaps config value is not respected, you can see in the video once i open opencode and move the focus to other pane outside of it and press a, then there is a warning from opencode

"no permission request to accept"



https://github.com/user-attachments/assets/dd8651de-5c32-4290-a012-8fa0cfded59e

