### PR TITLE
feat(keymap): allow disabling specific keymaps by setting to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,21 @@ Each keymap entry is a table consising of:
 - An optional mode: `{ 'toggle', mode = { 'n', 'i' } }`
 - An optional desc: `{'toggle', desc = 'Toggle Opencode' }`
 
+#### Disabling Specific Keymaps
+
+You can disable specific default keymaps by setting them to `false` in your configuration:
+
+```lua
+require('opencode').setup({
+  keymap = {
+    input_window = {
+      ['<cr>'] = false, -- Disable Enter key for submitting prompts
+      -- Other keymaps not specified will keep their default bindings
+    }
+  }
+})
+```
+
 ### UI icons (disable emojis or customize)
 
 By default, opencode.nvim uses emojis for icons in the UI. If you prefer a plain, emoji-free interface, you can switch to the `text` preset or override icons individually.

--- a/lua/opencode/keymap.lua
+++ b/lua/opencode/keymap.lua
@@ -9,7 +9,9 @@ local function process_keymap_entry(keymap_config, default_modes, base_opts)
   local cmds = api.commands
 
   for key_binding, config_entry in pairs(keymap_config) do
-    if config_entry then
+    if config_entry == false then
+      -- Skip keymap if explicitly set to false (disabled)
+    elseif config_entry then
       local func_name = config_entry[1]
       local callback = type(func_name) == 'function' and func_name or api[func_name]
       local modes = config_entry.mode or default_modes


### PR DESCRIPTION
## Summary
- Add support for disabling specific default keymaps by setting them to `false` in configuration
- Users can now selectively disable keymaps they don't need while keeping others

## Changes
- Modified `lua/opencode/keymap.lua`: Added check for `false` values in `process_keymap_entry`
- Updated `README.md`: Added "Disabling Specific Keymaps" section with examples

## Example
```lua
require('opencode').setup({
 keymap = {
   input_window = {
     ['<cr>'] = false,          -- Disable Enter key for submitting prompts
     ['<esc>'] = false,         -- Disable ESC key for closing
     -- Other keymaps not specified will keep their default bindings
   }
 }
})
```