### PR TITLE
fix(api): limit help description width to avoid string.format error

### DIFF
--- a/lua/opencode/api.lua
+++ b/lua/opencode/api.lua
@@ -496,7 +496,7 @@ function M.help()
     return
   end
 
-  local max_desc_length = vim.api.nvim_win_get_width(state.windows.output_win) - 30
+  local max_desc_length = math.min(90, vim.api.nvim_win_get_width(state.windows.output_win) - 30)
 
   local sorted_commands = vim.tbl_keys(M.commands)
   table.sort(sorted_commands)


### PR DESCRIPTION
## Summary

Fixes a bug where running `/help` command in Opencode with `position='current'` configuration triggers an error:

```
Error executing vim.schedule lua callback: ...opencode.nvim/lua/opencode/api.lua:510: invalid option '%-131' to 'format'
```

## Root Cause

Lua's `string.format` function has a maximum width limit of 99 characters for format specifiers. When `position='current'` is configured, the output window opens in the current window with a very large width (e.g., 161 characters). The code calculates `max_desc_length = window_width - 30`, which can exceed 99 and trigger the "invalid conversion specification" error.

## Fix

Cap `max_desc_length` at 90 characters to stay safely under the 99-character limit:

```lua
local max_desc_length = math.min(90, vim.api.nvim_win_get_width(state.windows.output_win) - 30)
```

## Testing

- Tested with `position='current'` configuration
- `/help` command now works correctly without errors
- Tested with various window sizes