### PR TITLE
fix: pass config.ui.picker to history, reference, and timeline pickers

### DIFF
--- a/lua/opencode/ui/history_picker.lua
+++ b/lua/opencode/ui/history_picker.lua
@@ -105,6 +105,7 @@ function M.pick(callback)
     end,
     title = 'Select History Entry',
     width = config.ui.picker_width or 100,
+    layout_opts = config.ui.picker,
   })
 end
 

--- a/lua/opencode/ui/reference_picker.lua
+++ b/lua/opencode/ui/reference_picker.lua
@@ -223,6 +223,7 @@ function M.pick()
     title = 'Code References (' .. #references .. ')',
     width = config.ui.picker_width or 100,
     preview = 'file',
+    layout_opts = config.ui.picker,
   })
 end
 

--- a/lua/opencode/ui/timeline_picker.lua
+++ b/lua/opencode/ui/timeline_picker.lua
@@ -42,6 +42,7 @@ function M.pick(messages, callback)
     callback = callback,
     title = 'Timeline',
     width = config.ui.picker_width or 100,
+    layout_opts = config.ui.picker,
   })
 end
 


### PR DESCRIPTION
In my other PR, I only passed the config.ui.picker options through the session_picker. Forgot about the other 3