### PR TITLE
fix(ui): restore window settings when using position=current

### DIFF
--- a/lua/opencode/state.lua
+++ b/lua/opencode/state.lua
@@ -16,6 +16,7 @@
 ---@field last_output_window_position integer[]|nil
 ---@field last_code_win_before_opencode integer|nil
 ---@field current_code_buf number|nil
+---@field saved_window_options table|nil
 ---@field display_route any|nil
 ---@field current_mode string
 ---@field last_output number
@@ -61,6 +62,7 @@ local _state = {
   last_output_window_position = nil,
   last_code_win_before_opencode = nil,
   current_code_buf = nil,
+  saved_window_options = nil,
   display_route = nil,
   current_mode = nil,
   last_output = 0,

--- a/lua/opencode/ui/ui.lua
+++ b/lua/opencode/ui/ui.lua
@@ -31,6 +31,13 @@ function M.close_windows(windows)
     if state.current_code_buf and vim.api.nvim_buf_is_valid(state.current_code_buf) then
       pcall(vim.api.nvim_win_set_buf, windows.output_win, state.current_code_buf)
     end
+    -- Restore original window options
+    if state.saved_window_options and vim.api.nvim_win_is_valid(windows.output_win) then
+      for opt, value in pairs(state.saved_window_options) do
+        pcall(vim.api.nvim_set_option_value, opt, value, { win = windows.output_win })
+      end
+      state.saved_window_options = nil
+    end
   else
     pcall(vim.api.nvim_win_close, windows.output_win, true)
   end


### PR DESCRIPTION
## Summary

When using `position = 'current'` configuration, opencode modifies window options (wrap, number, relativenumber, signcolumn, etc.) on the current window. This PR ensures those settings are saved before modification and restored when opencode is closed.

## Problem

Previously, when closing opencode with `position = 'current'`, the window would retain opencode's settings (e.g., `wrap=true`, `number=false`) instead of reverting to the user's original settings.

## Solution

- Save original window option values before modifying them (only when `position = 'current'`)
- Restore saved values when closing opencode
- Store saved options in `state.saved_window_options`

## Files Changed

- `lua/opencode/state.lua` - Added `saved_window_options` field to state
- `lua/opencode/ui/output_window.lua` - Helper function `set_win_option()` that saves original values before setting
- `lua/opencode/ui/ui.lua` - Restore saved options in `close_windows()`