### PR TITLE
fix(ui): improve task tool output formatting

### DIFF
--- a/lua/opencode/types.lua
+++ b/lua/opencode/types.lua
@@ -219,7 +219,8 @@
 ---@field message string|nil Optional status or error message
 
 ---@class TaskToolMetadata: ToolMetadataBase
----@field summary OpencodeMessagePart[]
+---@field summary TaskToolSummaryItem[]
+---@field sessionId string|nil Child session ID
 
 ---@class WebFetchToolMetadata: ToolMetadataBase
 ---@field http_status number|nil HTTP response status code
@@ -279,6 +280,12 @@
 ---@class TaskToolInput
 ---@field prompt string The subtask prompt
 ---@field description string Description of the subtask
+---@field subagent_type string The type of specialized agent to use
+
+---@class TaskToolSummaryItem
+---@field id string Tool call ID
+---@field tool string Tool name
+---@field state { status: string, title?: string }
 
 ---@class MessageTokenCount
 ---@field reasoning number


### PR DESCRIPTION
## Summary
- Display agent type in task description (e.g., `@explore`)
- Show task summary items with status icons (completed/running/pending/error)
- Strip task_metadata tags from output for cleaner display
- Fix metadata.summary structure handling (items have `{id, tool, state}` not full parts)
- Add TaskToolSummaryItem type definition

## Problem
The task tool output was not displaying correctly because the code expected `metadata.summary` to contain full message parts but it actually contains a simpler structure with `{id, tool, state}` causing the UI to hang.

## Solution
Updated the formatter to properly handle the actual summary structure and display tool names with their titles for better context.