### PR TITLE
docs: add Snacks picker integration for opencode.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,9 +415,8 @@ You can configure a custom action in Snacks pickers to send selected files direc
             end
             picker:close()
 
-            -- Open opencode and add files as context
             require("opencode.core").open({
-              new_session = false, -- set to true to start a new session
+              new_session = false,
               focus = "input",
               start_insert = true,
             })


### PR DESCRIPTION
## Summary
- Add documentation showing how to configure a custom action in all Snacks file pickers (files, git_files, buffers, git_status, etc.) to send selected files to opencode.nvim context

## Test plan
- [x] Verify the code example works with Snacks picker
- [x] Confirm `<localleader>o` sends selected files to opencode context