### PR TITLE
feat: allow using alternative `opencode` binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ require('opencode').setup({
   default_global_keymaps = true, -- If false, disables all default global keymaps
   default_mode = 'build', -- 'build' or 'plan' or any custom configured. @see [OpenCode Agents](https://opencode.ai/docs/modes/)
   keymap_prefix = '<leader>o', -- Default keymap prefix for global keymaps change to your preferred prefix and it will be applied to all keymaps starting with <leader>o
+  opencode_executable = 'opencode', -- Name of your opencode binary
   keymap = {
     editor = {
       ['<leader>og'] = { 'toggle' }, -- Open opencode. Close if opened

--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -12,6 +12,7 @@ M.defaults = {
   default_mode = 'build',
   legacy_commands = true,
   keymap_prefix = '<leader>o',
+  opencode_executable = 'opencode',
   keymap = {
     editor = {
       ['<leader>og'] = { 'toggle', desc = 'Toggle Opencode window' },

--- a/lua/opencode/core.lua
+++ b/lua/opencode/core.lua
@@ -317,7 +317,7 @@ M.cancel = Promise.async(function()
 end)
 
 M.opencode_ok = Promise.async(function()
-  if vim.fn.executable('opencode') == 0 then
+  if vim.fn.executable(config.opencode_executable) == 0 then
     vim.notify(
       'opencode command not found - please install and configure opencode before using this plugin',
       vim.log.levels.ERROR
@@ -326,7 +326,7 @@ M.opencode_ok = Promise.async(function()
   end
 
   if not state.opencode_cli_version or state.opencode_cli_version == '' then
-    local result = Promise.system({ 'opencode', '--version' }):await()
+    local result = Promise.system({ config.opencode_executable, '--version' }):await()
     local out = (result and result.stdout or ''):gsub('%s+$', '')
     state.opencode_cli_version = out:match('(%d+%%.%d+%%.%d+)') or out
   end

--- a/lua/opencode/health.lua
+++ b/lua/opencode/health.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local health = vim.health or require('health')
+local config = require('opencode.config')
 local util = require('opencode.util')
 
 local function command_exists(cmd)
@@ -8,11 +9,11 @@ local function command_exists(cmd)
 end
 
 local function get_opencode_version()
-  if not command_exists('opencode') then
+  if not command_exists(config.opencode_executable) then
     return nil, 'opencode command not found'
   end
 
-  local result = vim.system({ 'opencode', '--version' }):wait()
+  local result = vim.system({ config.opencode_executable, '--version' }):wait()
   if result.code ~= 0 then
     return nil, 'Failed to get opencode version: ' .. (result.stderr or 'unknown error')
   end
@@ -28,7 +29,7 @@ local function check_opencode_cli()
   local state = require('opencode.state')
   local required_version = state.required_version
 
-  if not command_exists('opencode') then
+  if not command_exists(config.opencode_executable) then
     health.error('opencode command not found', {
       'Install opencode CLI from: https://docs.opencode.com/installation',
       'Ensure opencode is in your PATH',

--- a/lua/opencode/opencode_server.lua
+++ b/lua/opencode/opencode_server.lua
@@ -1,6 +1,7 @@
 local util = require('opencode.util')
 local safe_call = util.safe_call
 local Promise = require('opencode.promise')
+local config = require('opencode.config')
 
 --- @class OpencodeServer
 --- @field job any The vim.system job handle
@@ -80,7 +81,7 @@ function OpencodeServer:spawn(opts)
   opts = opts or {}
 
   self.job = vim.system({
-    'opencode',
+    config.opencode_executable,
     'serve',
   }, {
     cwd = opts.cwd,

--- a/lua/opencode/types.lua
+++ b/lua/opencode/types.lua
@@ -196,6 +196,7 @@
 ---@field default_global_keymaps boolean
 ---@field default_mode 'build' | 'plan' | string -- Default mode
 ---@field keymap_prefix string
+---@field opencode_executable 'opencode' | string -- Command run for calling opencode
 ---@field keymap OpencodeKeymap
 ---@field ui OpencodeUIConfig
 ---@field context OpencodeContextConfig


### PR DESCRIPTION
This PR adds support for using alternative `opencode` binaries. This is useful if you want to use an opencode binary that isn't in your PATH or if you want to use a wrapper script to run opencode. Tests pass on my machine with `./run_tests.sh`.

(this change was done by hand, then I had an LLM double-check I found all uses of the binary name)