### PR TITLE
fix(core): only fail startup on actual errors

### DIFF
--- a/lua/opencode/core.lua
+++ b/lua/opencode/core.lua
@@ -85,7 +85,17 @@ M.open = Promise.async(function(opts)
     ui.focus_output({ restore_position = are_windows_closed })
   end
 
-  local server = server_job.ensure_server():await()
+  local server
+  local server_ok, server_err = pcall(function()
+    server = server_job.ensure_server():await()
+  end)
+
+  if not server_ok or not server then
+    state.is_opening = false
+    vim.notify('Failed to start opencode server: ' .. tostring(server_err or 'Unknown error'), vim.log.levels.ERROR)
+    return Promise.new():reject(server_err or 'Server failed to start')
+  end
+
   state.opencode_server = server
 
   local ok, err = pcall(function()


### PR DESCRIPTION
The latest version of OpenCode (1.1.35) outputs a log line to stderr on startup (see https://github.com/anomalyco/opencode/issues/10506 ). This causes the NeoVim plugin to hang indefinitely.

This commit makes two changes:
1. If we fail to start the OpenCode server, we display a notification with the error rather than hanging indefinitely.
2. We don't allow DEBUG, INFO, or WARN-level messages to fail initialization.