### PR TITLE
fix(context): simplify file addition logic

### DIFF
--- a/lua/opencode/context/chat_context.lua
+++ b/lua/opencode/context/chat_context.lua
@@ -193,16 +193,6 @@ end
 function M.add_file(file)
   local is_file = vim.fn.filereadable(file) == 1
   local is_dir = vim.fn.isdirectory(file) == 1
-  if not is_file and not is_dir then
-    vim.notify('File not added to context. Could not read.')
-    return
-  end
-
-  if not util.is_path_in_cwd(file) and not util.is_temp_path(file, 'pasted_image') then
-    vim.notify('File not added to context. Must be inside current working directory.')
-    return
-  end
-
   file = vim.fn.fnamemodify(file, ':p')
 
   if not M.context.mentioned_files then


### PR DESCRIPTION
- These checks are already present [upstream](https://github.com/sudo-tee/opencode.nvim/blob/main/lua/opencode/context.lua#L88) in the call stack.

- Primary motivation is that I wanted to be able to add files outside the current working directory to the context. This enables clients to do so by using `require("opencode.context").ChatContext.add_file`bypassing these checks instead of `require("opencode.context").add_file` which still won't allow it.