### PR TITLE
feat(ui): only auto hide input if contents empty

### DIFF
--- a/lua/opencode/ui/input_window.lua
+++ b/lua/opencode/ui/input_window.lua
@@ -393,7 +393,14 @@ function M.setup_autocmds(windows, group)
     callback = function()
       -- Auto-hide input window when auto_hide is enabled and focus leaves
       -- Don't hide if displaying a route (slash command output like /help)
-      if config.ui.input.auto_hide and not M.is_hidden() and not state.display_route then
+      -- Don't hide if input contains content
+      if
+        config.ui.input.auto_hide
+        and not M.is_hidden()
+        and not state.display_route
+        and #state.input_content == 1
+        and state.input_content[1] == ''
+      then
         M._hide()
       end
     end,


### PR DESCRIPTION
I really like the auto-hide feature for the input but I wish it would stay open while drafting a new prompt. It's easy to forget what you were composing if the window is hidden. that's why I added a condition to check if it's empty before hiding the window. let me know what you think
