### PR TITLE
fix(ui): fix tip of cancel keymap in footer

### DIFF
--- a/lua/opencode/ui/footer.lua
+++ b/lua/opencode/ui/footer.lua
@@ -36,7 +36,7 @@ local function build_right_segments()
   local segments = {}
 
   if state.is_running() and not state.is_opening then
-    local cancel_keymap = config.get_key_for_function('input_window', 'stop') or '<C-c>'
+    local cancel_keymap = config.get_key_for_function('input_window', 'cancel') or '<C-c>'
     table.insert(segments, { string.format('%s ', cancel_keymap), 'OpencodeInputLegend' })
     table.insert(segments, { 'to cancel', 'OpencodeHint' })
     table.insert(segments, { ' ' })


### PR DESCRIPTION
Problem: Wrong (maybe legacy i guess) name when getting the cancel keymap. This causes the tip in the footer is always `<C-c>` even if I set another key.