### PR TITLE
fix(context): allow selection without `current_file` option enabled

### DIFF
--- a/lua/opencode/context/base_context.lua
+++ b/lua/opencode/context/base_context.lua
@@ -149,6 +149,20 @@ function M.get_current_file(buf, context_config)
 end
 
 ---@param buf integer
+---@return table|nil
+function M.get_current_file_for_selection(buf)
+  local file = vim.api.nvim_buf_get_name(buf)
+  if not file or file == '' or vim.fn.filereadable(file) ~= 1 then
+    return nil
+  end
+  return {
+    path = file,
+    name = vim.fn.fnamemodify(file, ':t'),
+    extension = vim.fn.fnamemodify(file, ':e'),
+  }
+end
+
+---@param buf integer
 ---@param win integer
 ---@param context_config? OpencodeContextConfig
 ---@return table|nil

--- a/lua/opencode/context/chat_context.lua
+++ b/lua/opencode/context/chat_context.lua
@@ -387,11 +387,16 @@ function M.load()
   M.context.linter_errors = M.get_diagnostics(buf, nil, nil)
 
   -- Handle current selection
-  local current_selection = base_context.get_current_selection()
-  if current_selection and M.context.current_file then
-    local selection =
-      base_context.new_selection(M.context.current_file, current_selection.text, current_selection.lines)
-    M.add_selection(selection)
+  if base_context.is_context_enabled('selection') then
+    local current_selection = base_context.get_current_selection()
+    if current_selection then
+      local selection_file = base_context.get_current_file_for_selection(buf)
+      if selection_file then
+        local selection =
+          base_context.new_selection(selection_file, current_selection.text, current_selection.lines)
+        M.add_selection(selection)
+      end
+    end
   end
 end
 
@@ -486,7 +491,7 @@ M.format_message = Promise.async(function(prompt, opts)
     local selections = {}
 
     if range and range.start and range.stop then
-      local file = base_context.get_current_file(buf, context_config)
+      local file = base_context.get_current_file_for_selection(buf)
       if file then
         local selection = base_context.new_selection(
           file,
@@ -502,7 +507,7 @@ M.format_message = Promise.async(function(prompt, opts)
 
     local current_selection = base_context.get_current_selection(context_config)
     if current_selection then
-      local file = base_context.get_current_file(buf, context_config)
+      local file = base_context.get_current_file_for_selection(buf)
       if file then
         local selection = base_context.new_selection(file, current_selection.text, current_selection.lines)
         table.insert(selections, selection)

--- a/tests/unit/context_spec.lua
+++ b/tests/unit/context_spec.lua
@@ -104,6 +104,54 @@ describe('format_message', function()
     assert.is_true(found_file)
     assert.is_true(found_agent)
   end)
+
+  it('includes selection even when current_file context is disabled', function()
+    local ChatContext = require('opencode.context.chat_context')
+    local BaseContext = require('opencode.context.base_context')
+    local original_get_current_buf = BaseContext.get_current_buf
+    local original_get_current_selection = BaseContext.get_current_selection
+    local original_get_current_file_for_selection = BaseContext.get_current_file_for_selection
+
+    ChatContext.context.current_file = nil
+    ChatContext.context.mentioned_files = {}
+    ChatContext.context.mentioned_subagents = {}
+    ChatContext.context.selections = {}
+
+    BaseContext.get_current_buf = function()
+      return 1, 1
+    end
+    BaseContext.get_current_selection = function()
+      return { text = 'print("hello")', lines = '3, 4' }
+    end
+    BaseContext.get_current_file_for_selection = function()
+      return { path = '/tmp/foo.lua', name = 'foo.lua', extension = 'lua' }
+    end
+
+    local parts = context.format_message('test prompt', {
+      current_file = { enabled = false },
+      selection = { enabled = true },
+    }):wait()
+
+    local selection_json = nil
+    local has_file_part = false
+    for _, part in ipairs(parts) do
+      if part.type == 'file' then
+        has_file_part = true
+      end
+      local json = context.decode_json_context(part.text or '', 'selection')
+      if json then
+        selection_json = json
+      end
+    end
+
+    assert.is_false(has_file_part)
+    assert.is_not_nil(selection_json)
+    assert.same({ path = '/tmp/foo.lua', name = 'foo.lua', extension = 'lua' }, selection_json.file)
+
+    BaseContext.get_current_buf = original_get_current_buf
+    BaseContext.get_current_selection = original_get_current_selection
+    BaseContext.get_current_file_for_selection = original_get_current_file_for_selection
+  end)
 end)
 
 describe('delta_context', function()


### PR DESCRIPTION
adding selection ranges to the context (e.g. using the `focus_input` keymap in visual mode) currently depends on `context.current_file` being enabled.
unless I misunderstood something, I believe this coupling is unintentional and might have been added by mistake. passing the entire current file as context defeats the purpose of the targeted selection (results in unnecessary context bloat)

no changes to quick chat as it already works on selection without passing the whole file/buffer as context
