### PR TITLE
fix(ui): hide disabled commands

### DIFF
--- a/lua/opencode/ui/input_window.lua
+++ b/lua/opencode/ui/input_window.lua
@@ -329,8 +329,9 @@ function M.refresh_placeholder(windows, input_lines)
     end
     if context_key then
       table.insert(virt_text, { context_key, 'OpencodeInputLegend' })
-      table.insert(virt_text, { ' context' .. padding, 'OpencodeHint' })
+      table.insert(virt_text, { ' context', 'OpencodeHint' })
     end
+    table.insert(virt_text, { padding, 'OpencodeHint' })
     vim.api.nvim_buf_set_extmark(windows.input_buf, ns_id, 0, 0, {
       virt_text = virt_text,
       virt_text_pos = 'overlay',


### PR DESCRIPTION
when using a custom keymap the user might choose to disable some of the builtin commands. for example I use the brilliant integration with the Snacks files picker [https://github.com/sudo-tee/opencode.nvim?tab=readme-ov-file#snacks-picker-integration-with-opencode](https://github.com/sudo-tee/opencode.nvim?tab=readme-ov-file#snacks-picker-integration-with-opencode)

therefore I've disabled the `~` files command in my config

```lua
{
  keymap = {
    input_window = {
      ["~"] = false,
    },
  },
}
```

the UI would still show a hint for the disabled command but the mapping does not exist. with this we only show hints for commands that are actually enabled.
