### PR TITLE
perf: optimize string concatenation and namespace caching

### DIFF
--- a/lua/opencode/id.lua
+++ b/lua/opencode/id.lua
@@ -18,14 +18,14 @@ local LENGTH = 26
 -- Generate random base62 string
 local function random_base62(length)
   local chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
-  local result = ''
+  local parts = {}
 
-  for _ = 1, length do
+  for i = 1, length do
     local rand = math.random(1, 62)
-    result = result .. chars:sub(rand, rand)
+    parts[i] = chars:sub(rand, rand)
   end
 
-  return result
+  return table.concat(parts)
 end
 
 -- Convert number to hex string with padding
@@ -81,11 +81,12 @@ local function generate_new_id(prefix, descending)
   end
 
   -- Extract 6 bytes (48 bits) from the timestamp
-  local time_bytes = ''
+  local time_parts = {}
   for i = 5, 0, -1 do
     local byte_val = band(rshift(now, i * 8), 0xff)
-    time_bytes = time_bytes .. to_hex_padded(byte_val, 1)
+    time_parts[6 - i] = to_hex_padded(byte_val, 1)
   end
+  local time_bytes = table.concat(time_parts)
 
   -- Generate random suffix
   local random_suffix = random_base62(LENGTH - 12)

--- a/lua/opencode/ui/input_window.lua
+++ b/lua/opencode/ui/input_window.lua
@@ -8,6 +8,9 @@ M._hidden = false
 M._toggling = false
 M._resize_scheduled = false
 
+-- Cache namespace ID to avoid repeated creation
+local placeholder_ns = vim.api.nvim_create_namespace('input_placeholder')
+
 local function get_content_height(windows)
   local line_count = vim.api.nvim_buf_line_count(windows.input_buf)
   if line_count <= 0 then
@@ -303,7 +306,7 @@ function M.refresh_placeholder(windows, input_lines)
     input_lines = vim.api.nvim_buf_get_lines(windows.input_buf, 0, -1, false)
   end
   if #input_lines == 1 and input_lines[1] == '' then
-    local ns_id = vim.api.nvim_create_namespace('input_placeholder')
+    local ns_id = placeholder_ns
     local win_width = vim.api.nvim_win_get_width(windows.input_win)
     local padding = string.rep(' ', win_width)
     local slash_key = config.get_key_for_function('input_window', 'slash_commands')
@@ -338,7 +341,7 @@ function M.refresh_placeholder(windows, input_lines)
       virt_text_pos = 'overlay',
     })
   else
-    vim.api.nvim_buf_clear_namespace(windows.input_buf, vim.api.nvim_create_namespace('input_placeholder'), 0, -1)
+    vim.api.nvim_buf_clear_namespace(windows.input_buf, placeholder_ns, 0, -1)
   end
 end
 
@@ -346,7 +349,7 @@ function M.clear_placeholder(windows)
   if not windows or not windows.input_buf then
     return
   end
-  vim.api.nvim_buf_clear_namespace(windows.input_buf, vim.api.nvim_create_namespace('input_placeholder'), 0, -1)
+  vim.api.nvim_buf_clear_namespace(windows.input_buf, placeholder_ns, 0, -1)
 end
 
 function M.recover_input(windows)


### PR DESCRIPTION
Summary
- Replace string concatenation in loops with `table.concat` in ID generation
- Cache namespace ID at module level instead of repeated creation
 Changes
 `lua/opencode/id.lua`
- `random_base62()`: Use table + `table.concat` instead of `result = result .. char` (O(n) vs O(n²))
- `generate_new_id()`: Same optimization for timestamp byte extraction
 `lua/opencode/ui/input_window.lua`
- Cache `placeholder_ns` at module level
- Remove 3 redundant `nvim_create_namespace('input_placeholder')` calls
 Why
String concatenation in Lua creates new string objects each iteration, causing O(n²) complexity. While the impact is minimal for short strings (26 chars), this follows better Lua practices.
Namespace IDs are stable for the same name, but caching avoids unnecessary function calls on every placeholder refresh.