### PR TITLE
fix(formatter): format optional grep args

### DIFF
--- a/lua/opencode/ui/formatter.lua
+++ b/lua/opencode/ui/formatter.lua
@@ -560,14 +560,12 @@ end
 ---@param input GrepToolInput data for the tool
 ---@param metadata GrepToolMetadata Metadata for the tool use
 function M._format_grep_tool(output, input, metadata)
-  input = input or { path = '', include = '', pattern = '' }
-
-  local grep_str = vim
-    .iter({ input.path, input.include, input.pattern })
-    :filter(function(s)
-      return s ~= nil
-    end)
-    :join('` `')
+  local grep_str = table.concat(
+    vim.tbl_filter(function(part)
+      return part ~= nil
+    end, { input.path or input.include, input.pattern }),
+    '` `'
+  )
 
   M.format_action(output, icons.get('search') .. ' grep', grep_str)
   if not config.ui.output.tools.show_output then


### PR DESCRIPTION
this prevents optional grep arguments from showing up as `` (empty string in backticks). render-markdown does not like them either