### PR TITLE
fix(ui): fix invalid win id error

### DIFF
--- a/lua/opencode/ui/input_window.lua
+++ b/lua/opencode/ui/input_window.lua
@@ -569,6 +569,9 @@ function M._show()
   local was_at_bottom = output_window.viewport_at_bottom
 
   local output_win = windows.output_win
+  if not vim.api.nvim_win_is_valid(output_win) then
+    return
+  end
   vim.api.nvim_set_current_win(output_win)
 
   local input_position = config.ui.input_position or 'bottom'


### PR DESCRIPTION
sometimes I get this error while opencode is running but its window is hidden

```
vim.schedule callback: ...im/lazy/opencode-native/lua/opencode/ui/input_window.lua:572: Invalid window id: 1034
stack traceback:
	[C]: in function 'nvim_set_current_win'
	...im/lazy/opencode-native/lua/opencode/ui/input_window.lua:572: in function '_show'
	...are/nvim/lazy/opencode-native/lua/opencode/ui/dialog.lua:151: in function 'teardown'
	...zy/opencode-native/lua/opencode/ui/permission_window.lua:183: in function '_clear_dialog'
	...zy/opencode-native/lua/opencode/ui/permission_window.lua:196: in function 'clear_all'
	...e/nvim/lazy/opencode-native/lua/opencode/ui/renderer.lua:56: in function 'reset'
	...e/nvim/lazy/opencode-native/lua/opencode/ui/renderer.lua:110: in function 'teardown'
	...l/share/nvim/lazy/opencode-native/lua/opencode/ui/ui.lua:22: in function 'close_windows'
	...e/nvim/lazy/opencode-native/lua/opencode/ui/autocmds.lua:24: in function <...e/nvim/lazy/opencode-native/lua/opencode/ui/autocmds.lua:23>
```