### PR TITLE
fix(ui): add defensive guards for async window/buffer operations

### DIFF
--- a/lua/opencode/ui/loading_animation.lua
+++ b/lua/opencode/ui/loading_animation.lua
@@ -97,8 +97,8 @@ end
 function M.stop()
   M._clear_animation_timer()
   M._animation.current_frame = 1
-  if state.windows and state.windows.footer_buf then
-    vim.api.nvim_buf_clear_namespace(state.windows.footer_buf, M._animation.ns_id, 0, -1)
+  if state.windows and state.windows.footer_buf and vim.api.nvim_buf_is_valid(state.windows.footer_buf) then
+    pcall(vim.api.nvim_buf_clear_namespace, state.windows.footer_buf, M._animation.ns_id, 0, -1)
   end
 end
 

--- a/lua/opencode/ui/topbar.lua
+++ b/lua/opencode/ui/topbar.lua
@@ -16,7 +16,10 @@ local function format_token_info()
   if state.current_model then
     if config.ui.display_context_size then
       local provider, model = state.current_model:match('^(.-)/(.+)$')
-      local model_info = config_file.get_model_info(provider, model)
+      local ok, model_info = pcall(config_file.get_model_info, provider, model)
+      if not ok then
+        model_info = nil
+      end
       local limit = state.tokens_count and model_info and model_info.limit and model_info.limit.context or 0
       table.insert(parts, util.format_number(state.tokens_count) or nil)
       if limit > 0 then
@@ -92,7 +95,7 @@ function M.render()
       return
     end
     local win = state.windows.output_win
-    if not win then
+    if not win or not vim.api.nvim_win_is_valid(win) then
       return
     end
 

--- a/tests/unit/curl_spec.lua
+++ b/tests/unit/curl_spec.lua
@@ -1,0 +1,57 @@
+local curl = require('opencode.curl')
+
+describe('curl stream handle lifecycle', function()
+  local original_system
+
+  before_each(function()
+    original_system = vim.system
+  end)
+
+  after_each(function()
+    vim.system = original_system
+  end)
+
+  it('marks stream handle as stopped after process exit', function()
+    local on_complete
+
+    vim.system = function(_, _, cb)
+      on_complete = cb
+      return {
+        pid = 123,
+        kill = function() end,
+      }
+    end
+
+    local handle = curl.request({
+      url = 'http://127.0.0.1:1/event',
+      stream = function() end,
+    })
+
+    assert.is_true(handle.is_running())
+    on_complete({ code = 0, signal = 0 })
+    assert.is_false(handle.is_running())
+  end)
+
+  it('marks stream handle as stopped on shutdown', function()
+    local killed = false
+
+    vim.system = function(_, _, _)
+      return {
+        pid = 123,
+        kill = function()
+          killed = true
+        end,
+      }
+    end
+
+    local handle = curl.request({
+      url = 'http://127.0.0.1:1/event',
+      stream = function() end,
+    })
+
+    handle.shutdown()
+
+    assert.is_true(killed)
+    assert.is_false(handle.is_running())
+  end)
+end)


### PR DESCRIPTION
- topbar: pcall wrap winbar setting + win_is_valid check before render
- loading_animation: buf_is_valid guard + pcall for extmark operations
- curl: explicit is_running boolean flag instead of job.pid check (job.pid persists after process exit, causing false health check positives)
- Add curl lifecycle tests