### PR TITLE
feat(ui): add reference_picker_center_on_jump config

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ require('opencode').setup({
     display_context_size = true, -- Display context size in the footer
     display_cost = true, -- Display cost in the footer
     window_highlight = 'Normal:OpencodeBackground,FloatBorder:OpencodeBorder', -- Highlight group for the opencode window
+    reference_picker_center_on_jump = false, -- Center viewport (zz) when jumping to a code reference (default: false)
     icons = {
       preset = 'nerdfonts', -- 'nerdfonts' | 'text'. Choose UI icon style (default: 'nerdfonts')
       overrides = {}, -- Optional per-key overrides, see section below

--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -116,6 +116,7 @@ M.defaults = {
     display_context_size = true,
     display_cost = true,
     window_highlight = 'Normal:OpencodeBackground,FloatBorder:OpencodeBorder',
+    reference_picker_center_on_jump = false,
     icons = {
       preset = 'nerdfonts',
       overrides = {},

--- a/lua/opencode/types.lua
+++ b/lua/opencode/types.lua
@@ -121,6 +121,7 @@
 ---@field display_context_size boolean
 ---@field display_cost boolean
 ---@field window_highlight string
+---@field reference_picker_center_on_jump boolean
 ---@field icons { preset: 'text'|'nerdfonts', overrides: table<string,string> }
 ---@field loading_animation OpencodeLoadingAnimationConfig
 ---@field output OpencodeUIOutputConfig

--- a/lua/opencode/ui/reference_picker.lua
+++ b/lua/opencode/ui/reference_picker.lua
@@ -308,7 +308,9 @@ function M.navigate_to(ref)
     line = math.min(line, line_count)
 
     vim.api.nvim_win_set_cursor(0, { line, col })
-    vim.cmd('normal! zz')
+    if config.ui.reference_picker_center_on_jump then
+      vim.cmd('normal! zz')
+    end
   end
 end
 


### PR DESCRIPTION
- Default false : center viewport when jumping to code references.