### PR TITLE
fix(input): prevent cursor jumps on context completion trigger

### DIFF
--- a/lua/opencode/api.lua
+++ b/lua/opencode/api.lua
@@ -364,7 +364,7 @@ end
 
 function M.context_items()
   local char = config.get_key_for_function('input_window', 'context_items')
-  ui.focus_input({ restore_position = true, start_insert = true })
+  ui.focus_input({ restore_position = false, start_insert = true })
   require('opencode.ui.completion').trigger_completion(char)()
 end
 

--- a/lua/opencode/ui/ui.lua
+++ b/lua/opencode/ui/ui.lua
@@ -136,8 +136,11 @@ function M.focus_input(opts)
     return
   end
 
+  local was_input_focused = vim.api.nvim_get_current_win() == windows.input_win
+
   if input_window.is_hidden() then
     input_window._show()
+    was_input_focused = false
   end
 
   if not windows.input_win then
@@ -146,7 +149,7 @@ function M.focus_input(opts)
 
   vim.api.nvim_set_current_win(windows.input_win)
 
-  if opts.restore_position and state.last_input_window_position then
+  if opts.restore_position and not was_input_focused and state.last_input_window_position then
     pcall(vim.api.nvim_win_set_cursor, 0, state.last_input_window_position)
   end
   if vim.api.nvim_get_current_win() == windows.input_win and opts.start_insert then

--- a/tests/unit/api_spec.lua
+++ b/tests/unit/api_spec.lua
@@ -146,6 +146,40 @@ describe('opencode.api', function()
     end)
   end)
 
+  describe('completion triggers', function()
+    it('does not restore cursor position for context_items', function()
+      local config = require('opencode.config')
+      local original_get_key_for_function = config.get_key_for_function
+      local original_completion = package.loaded['opencode.ui.completion']
+
+      config.get_key_for_function = function(scope, function_name)
+        if scope == 'input_window' and function_name == 'context_items' then
+          return '#'
+        end
+        return original_get_key_for_function(scope, function_name)
+      end
+
+      local trigger_char = nil
+      package.loaded['opencode.ui.completion'] = {
+        trigger_completion = function(char)
+          return function()
+            trigger_char = char
+          end
+        end,
+      }
+
+      stub(ui, 'focus_input')
+
+      api.context_items()
+
+      config.get_key_for_function = original_get_key_for_function
+      package.loaded['opencode.ui.completion'] = original_completion
+
+      assert.stub(ui.focus_input).was_called_with({ restore_position = false, start_insert = true })
+      assert.equal('#', trigger_char)
+    end)
+  end)
+
   describe('run command argument parsing', function()
     it('parses agent prefix and passes to send_message', function()
       api.commands.run.fn({ 'agent=plan', 'analyze', 'this', 'code' }):wait()


### PR DESCRIPTION
when inserting the context completion trigger (`#`) the cursor could jump to another location because it tried restoring a formerly saved cursor position. this is likely a regression of [`https://github.com/sudo-tee/opencode.nvim/commit/22ee4f0f76e7b7de60a57f9a524893e50f0edbc4`](https://github.com/sudo-tee/opencode.nvim/commit/22ee4f0f76e7b7de60a57f9a524893e50f0edbc4)

I also added a safeguard so that we never attempt to restore a saved cursor location when the input window is already focused