### PR TITLE
feat(api): add opts parameter to add_visual_selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,7 +615,16 @@ The plugin provides the following actions that can be triggered via keymaps, com
 | Toggle tools output (diffs, cmd output, etc.)               | `<leader>ott`                         | `:Opencode toggle_tool_output`              | `require('opencode.api').toggle_tool_output()`                         |
 | Toggle reasoning output (thinking steps)                    | `<leader>otr`                         | `:Opencode toggle_reasoning_output`         | `require('opencode.api').toggle_reasoning_output()`                    |
 | Open a quick chat input with selection/current line context | `<leader>o/`                          | `:Opencode quick_chat`                      | `require('opencode.api').quick_chat()`                                 |
-| Add visual selection to context                             | `<leader>oy`                          | `:Opencode add_visual_selection`            | `require('opencode.api').add_visual_selection()`                       |
+| Add visual selection to context                             | `<leader>oy`                          | `:Opencode add_visual_selection`            | `require('opencode.api').add_visual_selection(opts?)`                  |
+
+**add_visual_selection opts:**
+
+- `open_input` (boolean, default: `true`): Whether to open the input window after adding the selection. Set to `false` to add selection silently without changing focus.
+
+Example keymap for silent add:
+```lua
+['<leader>oY'] = { 'add_visual_selection', { open_input = false }, mode = {'v'} }
+```
 
 ### Run opts
 

--- a/lua/opencode/api.lua
+++ b/lua/opencode/api.lua
@@ -1013,16 +1013,15 @@ M.review = Promise.async(function(args)
     end)
 end)
 
---- Add the current visual selection to the context without opening/focusing the panel.
---- Can be called from any buffer. Selections accumulate across files.
 M.add_visual_selection = Promise.async(
-  ---@param _ any Unused
+  ---@param opts? {open_input?: boolean}
   ---@param range OpencodeSelectionRange
-  function(_, range)
+  function(opts, range)
+    opts = vim.tbl_extend('force', { open_input = true }, opts or {})
     local context = require('opencode.context')
     local added = context.add_visual_selection(range)
 
-    if added then
+    if added and opts.open_input then
       M.open_input():await()
     end
   end

--- a/lua/opencode/keymap.lua
+++ b/lua/opencode/keymap.lua
@@ -27,7 +27,16 @@ local function process_keymap_entry(keymap_config, default_modes, base_opts, def
       -- Skip keymap if explicitly set to false (disabled)
     elseif config_entry then
       local func_name = config_entry[1]
-      local callback = type(func_name) == 'function' and func_name or api[func_name]
+      local func_args = config_entry[2]
+      local raw_callback = type(func_name) == 'function' and func_name or api[func_name]
+      local callback = raw_callback
+
+      if raw_callback and func_args then
+        callback = function()
+          raw_callback(func_args)
+        end
+      end
+
       local modes = config_entry.mode or default_modes
       local opts = vim.tbl_deep_extend('force', {}, base_opts)
       opts.desc = config_entry.desc or cmds[func_name] and cmds[func_name].desc


### PR DESCRIPTION
Add optional opts.open_input (default: true) to control whether the input window opens after adding selection.