### PR TITLE
Add '.jj' to ignore patterns in config.lua

### DIFF
--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -156,6 +156,7 @@ M.defaults = {
           '^%.git/',
           '^%.svn/',
           '^%.hg/',
+          '^%.jj/',
           'node_modules/',
           '%.pyc$',
           '%.o$',


### PR DESCRIPTION
Ignore `.jj` directories for anyone using jujutsu for version control