### PR TITLE
fix(ui): allow subagent questions to display regardless of session ID

### DIFF
--- a/lua/opencode/ui/renderer.lua
+++ b/lua/opencode/ui/renderer.lua
@@ -998,10 +998,6 @@ function M.on_question_asked(properties)
     return
   end
 
-  if not state.active_session or properties.sessionID ~= state.active_session.id then
-    return
-  end
-
   local question_window = require('opencode.ui.question_window')
   question_window.show_question(properties)
 end


### PR DESCRIPTION
### Summary

Fix an issue where questions from subagents were not displayed because the `on_question_asked` event handler filtered questions by `sessionID`, comparing subagent session IDs against the main session ID.

### Root Cause

The `on_question_asked` event handler in `lua/opencode/ui/renderer.lua` (lines 1001-1003) filters questions by session ID:

```lua
if not state.active_session or properties.sessionID ~= state.active_session.id then
  return
end
```

When a subagent asks a question, it includes its own `sessionID` (not the main session's ID). However, `state.active_session` refers to the main session, so the comparison fails and the question is silently ignored.

### Issue Reproduction Steps

1. Start 2 nvim processes with opencode.nvim.
2. In opencode.nvim in the second nvim process, prompt a command that the agent take long time to work
3. In opencode.nvim in the first nvim process, prompt "@sugagent call tool to ask me a random question". Note that opencode in the second nvim process is still processing while the subagent in the first nvim process is asking question.

### Actual Behavior

- The question from the first nvim process is not shown

### Expected Behavior

- The question from the first nvim process should be shown

### Additional Context

- Question still works with the primary agent, even if multiple nvim processes are running

### Changes

- Remove the `sessionID` check in the `on_question_asked` handler (`lua/opencode/ui/renderer.lua`)

### Why This Is Safe

- Questions are stored one at a time in `question_window._current_question`, so conflicts are impossible
- The question reply endpoint uses the question's `requestID`, not the session ID, so answers route correctly
- Similar to the permission handler, which also doesn't filter by session ID
- No accumulated state or persistence issues like messages/parts have
