### PR TITLE
feat(lsp): adjust completion textEdit range to replace typed word

### DIFF
--- a/lua/opencode/lsp/opencode_ls.lua
+++ b/lua/opencode/lsp/opencode_ls.lua
@@ -91,13 +91,19 @@ end
 ---Convert opencode CompletionItem to LSP CompletionItem
 ---@param item CompletionItem
 ---@param index integer
+---@param params lsp.CompletionParams
+---@param word string Text after the trigger character to be completed
 ---@return OpencodeLspItem
-local function to_lsp_item(item, index, params)
+local function to_lsp_item(item, index, params, word)
   local source = require('opencode.ui.completion').get_source_by_name(item.source_name)
-  local kind = (source and source.custom_kind) or vim.lsp.protocol.CompletionItemKind.Function ---@type lsp.CompletionItemKind
+  local kind = (source and source.custom_kind) or
+  vim.lsp.protocol.CompletionItemKind.Function ---@type lsp.CompletionItemKind
   local priority = source and source.priority or 999
   local line = params.position.line
   local col = params.position.character
+
+  local start_char = col - #word
+  local end_char = col
 
   ---@type OpencodeLspItem
   local lsp_item = {
@@ -115,8 +121,8 @@ local function to_lsp_item(item, index, params)
     sortText = string.format('%02d_%02d_%02d_%s', priority, item.priority or 999, index, item.label),
     textEdit = {
       range = {
-        start = { line = line, character = col },
-        ['end'] = { line = line, character = col },
+        start = { line = line, character = start_char },
+        ['end'] = { line = line, character = end_char },
       },
       newText = item.insert_text,
     },
@@ -161,29 +167,29 @@ handlers[ms.textDocument_completion] = function(params, callback)
   end
 
   Promise.all(promises)
-    :and_then(function(results)
-      ---@type OpencodeLspItem[]
-      local all_items = {}
-      local is_incomplete = false
+      :and_then(function(results)
+        ---@type OpencodeLspItem[]
+        local all_items = {}
+        local is_incomplete = false
 
-      for _, items in ipairs(results) do
-        for j, item in ipairs(items or {}) do
-          local source = completion.get_source_by_name(item.source_name)
-          if source and source.is_incomplete then
-            is_incomplete = true
+        for _, items in ipairs(results) do
+          for j, item in ipairs(items or {}) do
+            local source = completion.get_source_by_name(item.source_name)
+            if source and source.is_incomplete then
+              is_incomplete = true
+            end
+
+            table.insert(all_items, to_lsp_item(item, j, params, word))
           end
-
-          table.insert(all_items, to_lsp_item(item, j, params))
         end
-      end
 
-      callback(nil, { isIncomplete = is_incomplete, items = all_items })
-    end)
-    :catch(function(err)
-      local log = require('opencode.log')
-      log.error('Error in completion handler: ' .. tostring(err))
-      callback(nil, { isIncomplete = false, items = {} })
-    end)
+        callback(nil, { isIncomplete = is_incomplete, items = all_items })
+      end)
+      :catch(function(err)
+        local log = require('opencode.log')
+        log.error('Error in completion handler: ' .. tostring(err))
+        callback(nil, { isIncomplete = false, items = {} })
+      end)
 end
 
 ---Create the LSP server configuration
@@ -231,7 +237,7 @@ function M.start(bufnr)
       local completed_item = vim.v.completed_item
       if completed_item and completed_item.user_data then
         local data = vim.tbl_get(completed_item, 'user_data', 'nvim', 'lsp', 'completion_item', 'data')
-          or vim.tbl_get(completed_item, 'user_data', 'lsp', 'item', 'data')
+            or vim.tbl_get(completed_item, 'user_data', 'lsp', 'item', 'data')
 
         local item = data and data._opencode_item
 

--- a/tests/unit/completion_lsp_spec.lua
+++ b/tests/unit/completion_lsp_spec.lua
@@ -1019,68 +1019,136 @@ describe('opencode LSP completion', function()
       end)
 
       it('embeds the original item in data._opencode_item', function()
-        package.loaded['blink.cmp'] = nil
-        package.loaded['opencode.lsp.opencode_ls'] = nil
-        ls = require('opencode.lsp.opencode_ls')
+         package.loaded['blink.cmp'] = nil
+         package.loaded['opencode.lsp.opencode_ls'] = nil
+         ls = require('opencode.lsp.opencode_ls')
 
-        package.loaded['opencode.ui.completion'] = nil
-        local completion = require('opencode.ui.completion')
-        completion._sources = {}
+         package.loaded['opencode.ui.completion'] = nil
+         local completion = require('opencode.ui.completion')
+         completion._sources = {}
 
-        local original_item = {
-          label = 'OriginalItem',
-          kind = 'file',
-          kind_icon = '',
-          insert_text = 'OriginalItem',
-          source_name = 'data_test_source',
-          data = { custom = 'value' },
-        }
+         local original_item = {
+           label = 'OriginalItem',
+           kind = 'file',
+           kind_icon = '',
+           insert_text = 'OriginalItem',
+           source_name = 'data_test_source',
+           data = { custom = 'value' },
+         }
 
-        completion.register_source({
-          name = 'data_test_source',
-          priority = 1,
-          complete = function()
-            return Promise.new():resolve({ original_item })
-          end,
-          get_trigger_character = function()
-            return '@'
-          end,
-        })
+         completion.register_source({
+           name = 'data_test_source',
+           priority = 1,
+           complete = function()
+             return Promise.new():resolve({ original_item })
+           end,
+           get_trigger_character = function()
+             return '@'
+           end,
+         })
 
-        vim.api.nvim_buf_get_lines = function()
-          return { '@test' }
-        end
-        vim.api.nvim_get_current_line = function()
-          return '@test'
-        end
-        vim.api.nvim_win_get_cursor = function()
-          return { 1, 5 }
-        end
+         vim.api.nvim_buf_get_lines = function()
+           return { '@test' }
+         end
+         vim.api.nvim_get_current_line = function()
+           return '@test'
+         end
+         vim.api.nvim_win_get_cursor = function()
+           return { 1, 5 }
+         end
 
-        local config_obj = ls.create_config()
-        local server = config_obj.cmd({}, {})
+         local config_obj = ls.create_config()
+         local server = config_obj.cmd({}, {})
 
-        local done = false
-        local callback_result = nil
-        server.request('textDocument/completion', {
-          position = { line = 0, character = 5 },
-        }, function(err, result)
-          callback_result = result
-          done = true
-        end)
+         local done = false
+         local callback_result = nil
+         server.request('textDocument/completion', {
+           position = { line = 0, character = 5 },
+         }, function(err, result)
+           callback_result = result
+           done = true
+         end)
 
-        vim.wait(200, function()
-          return done
-        end)
+         vim.wait(200, function()
+           return done
+         end)
 
-        assert.is_not_nil(callback_result)
-        assert.are.equal(1, #callback_result.items)
-        local lsp_item = callback_result.items[1]
-        assert.is_not_nil(lsp_item.data)
-        assert.is_not_nil(lsp_item.data._opencode_item)
-        assert.are.equal(original_item.label, lsp_item.data._opencode_item.label)
-        assert.are.equal('value', lsp_item.data._opencode_item.data.custom)
-      end)
+         assert.is_not_nil(callback_result)
+         assert.are.equal(1, #callback_result.items)
+         local lsp_item = callback_result.items[1]
+         assert.is_not_nil(lsp_item.data)
+         assert.is_not_nil(lsp_item.data._opencode_item)
+         assert.are.equal(original_item.label, lsp_item.data._opencode_item.label)
+         assert.are.equal('value', lsp_item.data._opencode_item.data.custom)
+       end)
+
+       it('calculates correct textEdit range to replace typed word', function()
+         package.loaded['blink.cmp'] = nil
+         package.loaded['opencode.lsp.opencode_ls'] = nil
+         ls = require('opencode.lsp.opencode_ls')
+
+         package.loaded['opencode.ui.completion'] = nil
+         local completion = require('opencode.ui.completion')
+         completion._sources = {}
+
+         local item_for_range_test = {
+           label = 'tests',
+           kind = 'file',
+           kind_icon = '',
+           insert_text = 'tests',
+           source_name = 'range_test_source',
+           data = {},
+         }
+
+         completion.register_source({
+           name = 'range_test_source',
+           priority = 1,
+           complete = function()
+             return Promise.new():resolve({ item_for_range_test })
+           end,
+           get_trigger_character = function()
+             return '@'
+           end,
+         })
+
+         vim.api.nvim_buf_get_lines = function()
+           return { '@te' }
+         end
+         vim.api.nvim_get_current_line = function()
+           return '@te'
+         end
+         vim.api.nvim_win_get_cursor = function()
+           return { 1, 3 }
+         end
+
+         local config_obj = ls.create_config()
+         local server = config_obj.cmd({}, {})
+
+         local done = false
+         local callback_result = nil
+         server.request('textDocument/completion', {
+           position = { line = 0, character = 3 },
+         }, function(err, result)
+           callback_result = result
+           done = true
+         end)
+
+         vim.wait(200, function()
+           return done
+         end)
+
+         assert.is_not_nil(callback_result)
+         assert.are.equal(1, #callback_result.items)
+         local lsp_item = callback_result.items[1]
+         assert.is_not_nil(lsp_item.textEdit)
+         assert.is_not_nil(lsp_item.textEdit.range)
+
+         local range = lsp_item.textEdit.range
+         assert.are.equal(1, range.start.character, 'start should be at trigger char position + 1')
+         assert.are.equal(3, range['end'].character, 'end should be at cursor position')
+         assert.are.equal(0, range.start.line, 'line should be 0')
+         assert.are.equal(0, range['end'].line, 'line should be 0')
+       end)
     end)
   end)
 end)


### PR DESCRIPTION
## Summary
Fix the LSP completion bug where selecting a completion item would duplicate the typed text (e.g., `@te` + "tests" → `@tetests` instead of `@tests`). The issue was caused by incorrect textEdit range calculation in the LSP completion handler.

## Changes
- **Fixed `to_lsp_item` function** in `lua/opencode/lsp/opencode_ls.lua` to correctly calculate the textEdit range
  - Added `word` parameter to accept the text after the trigger character
  - Calculate correct range: `start_char = col - #word`, `end_char = col`
  - This ensures LSP clients replace the typed text instead of appending to it

- **Updated completion handler** to pass the `word` parameter to `to_lsp_item`

- **Added comprehensive test** in `tests/unit/completion_lsp_spec.lua` that validates the textEdit range for the specific bug scenario

## Testing
- ✅ All 37 completion LSP tests pass (36 existing + 1 new)
- ✅ No regressions in existing completion functionality
- ✅ New test validates the exact scenario from the issue: `@te` completion → `@tests`

## Details
The bug occurred because the textEdit range had both `start` and `end` at the same cursor position, which inserted text instead of replacing it. The fix calculates the correct start position as the position right after the trigger character, allowing the LSP client to properly replace the already-typed word.
