### PR TITLE
fix(ui): respect custom user layout for all snacks pickers

### DIFF
--- a/lua/opencode/model_picker.lua
+++ b/lua/opencode/model_picker.lua
@@ -87,6 +87,7 @@ function M.select(cb)
   base_picker.pick({
     title = 'Select model',
     items = models,
+    layout_opts = config.ui.picker,
     format_fn = function(item, width)
       local icon = item.icon or ''
       local item_width = width or vim.api.nvim_win_get_width(0)

--- a/lua/opencode/ui/mcp_picker.lua
+++ b/lua/opencode/ui/mcp_picker.lua
@@ -178,6 +178,7 @@ function M.pick(callback)
     callback = default_callback,
     title = 'MCP Servers',
     width = 65,
+    layout_opts = config.ui.picker,
   })
 end
 

--- a/lua/opencode/variant_picker.lua
+++ b/lua/opencode/variant_picker.lua
@@ -1,6 +1,7 @@
 local M = {}
 local base_picker = require('opencode.ui.base_picker')
 local state = require('opencode.state')
+local config = require('opencode.config')
 local config_file = require('opencode.config_file')
 local model_state = require('opencode.model_state')
 local util = require('opencode.util')
@@ -64,6 +65,7 @@ function M.select(callback)
   base_picker.pick({
     title = 'Select variant',
     items = variants,
+    layout_opts = config.ui.picker,
     format_fn = function(item, width)
       local item_width = width or vim.api.nvim_win_get_width(0)
       local is_current = state.current_variant == item.name


### PR DESCRIPTION
custom snacks layout was only applied to some picker variants (e.g. session picker), not others (e.g. models picker)