### PR TITLE
feat(context): expose public API

### DIFF
--- a/lua/opencode/context.lua
+++ b/lua/opencode/context.lua
@@ -9,6 +9,26 @@ local BaseContext = require('opencode.context.base_context')
 
 local M = {}
 
+---@type table<OpencodeToggleableContextKey, boolean>
+local toggleable_context_keys = {
+  current_file = true,
+  selection = true,
+  diagnostics = true,
+  cursor_data = true,
+  buffer = true,
+  git_diff = true,
+}
+
+---@param context_key OpencodeToggleableContextKey
+---@return table
+local function ensure_context_state(context_key)
+  state.current_context_config = state.current_context_config or {}
+  local current = state.current_context_config[context_key]
+  local defaults = vim.tbl_get(config, 'context', context_key) or {}
+  state.current_context_config[context_key] = vim.tbl_deep_extend('force', {}, defaults, current or {})
+  return state.current_context_config[context_key]
+end
+
 M.ChatContext = ChatContext
 M.QuickChatContext = QuickChatContext
 
@@ -45,6 +65,33 @@ end
 
 function M.is_context_enabled(context_key, context_config)
   return BaseContext.is_context_enabled(context_key, context_config)
+end
+
+---@param context_key OpencodeToggleableContextKey
+---@param enabled boolean
+---@return boolean|nil enabled
+function M.set_context(context_key, enabled)
+  if not toggleable_context_keys[context_key] then
+    return nil
+  end
+
+  local context_state = ensure_context_state(context_key)
+  context_state.enabled = enabled
+
+  M.load()
+
+  return enabled
+end
+
+---@param context_key OpencodeToggleableContextKey
+---@return boolean|nil enabled
+function M.toggle_context(context_key)
+  if not toggleable_context_keys[context_key] then
+    return nil
+  end
+
+  local enabled = not M.is_context_enabled(context_key)
+  return M.set_context(context_key, enabled)
 end
 
 function M.get_diagnostics(buf, context_config, range)

--- a/lua/opencode/types.lua
+++ b/lua/opencode/types.lua
@@ -165,6 +165,14 @@
 ---@field buffer { enabled: boolean }
 ---@field git_diff { enabled: boolean }
 
+---@alias OpencodeToggleableContextKey
+---| 'current_file'
+---| 'selection'
+---| 'diagnostics'
+---| 'cursor_data'
+---| 'buffer'
+---| 'git_diff'
+
 ---@class OpencodeDebugConfig
 ---@field enabled boolean
 ---@field capture_streamed_events boolean

--- a/lua/opencode/ui/completion/context.lua
+++ b/lua/opencode/ui/completion/context.lua
@@ -1,6 +1,5 @@
 local config = require('opencode.config')
 local context = require('opencode.context')
-local state = require('opencode.state')
 local icons = require('opencode.ui.icons')
 local Promise = require('opencode.promise')
 
@@ -267,17 +266,7 @@ local context_source = {
     end
 
     local type = item.data.type
-    local context_cfg = vim.deepcopy(state.current_context_config or {})
-    if not context_cfg or not context_cfg[type] then
-      context_cfg[type] = vim.deepcopy(config.context[type])
-    end
-
-    if vim.tbl_contains({ 'current_file', 'selection', 'diagnostics', 'cursor_data' }, type) then
-      context_cfg[type] = context_cfg[type] or {}
-      context_cfg[type].enabled = not item.data.available
-    end
-
-    state.current_context_config = context_cfg
+    context.toggle_context(type)
 
     if type == 'mentioned_file' then
       local file_path = item.data.additional_data and item.data.additional_data.file_path or item.data.name

--- a/tests/unit/context_completion_spec.lua
+++ b/tests/unit/context_completion_spec.lua
@@ -53,6 +53,15 @@ describe('context completion', function()
       remove_file = function() end,
       remove_subagent = function() end,
       remove_selection = function() end,
+      toggle_context = function(type)
+        if not vim.tbl_contains({ 'current_file', 'selection', 'diagnostics', 'cursor_data', 'buffer', 'git_diff' }, type) then
+          return nil
+        end
+        mock_state.current_context_config = mock_state.current_context_config or {}
+        mock_state.current_context_config[type] = mock_state.current_context_config[type] or {}
+        mock_state.current_context_config[type].enabled = not mock_context.is_context_enabled(type)
+        return true
+      end,
       get_context = function()
         return {
           current_file = { extension = 'lua', name = 'test.lua', path = '/test/test.lua' },
@@ -300,6 +309,7 @@ describe('context completion', function()
     end)
 
     it('should toggle context enabled state for toggleable items', function()
+      local toggle_called = false
       local item = {
         label = 'Current File',
         data = {
@@ -309,13 +319,16 @@ describe('context completion', function()
         },
       }
 
+      local context_module = require('opencode.context')
+      context_module.toggle_context = function(type)
+        toggle_called = true
+        assert.are.equal('current_file', type)
+        return true
+      end
+
       source.on_complete(item)
 
-      local state_module = require('opencode.state')
-
-      assert.is_not_nil(state_module.current_context_config)
-      assert.is_not_nil(state_module.current_context_config.current_file)
-      assert.is_false(state_module.current_context_config.current_file.enabled)
+      assert.is_true(toggle_called)
     end)
 
     it('should remove mentioned file when selected', function()

--- a/tests/unit/context_spec.lua
+++ b/tests/unit/context_spec.lua
@@ -321,6 +321,66 @@ describe('context static API with config override', function()
   end)
 end)
 
+describe('context toggle API', function()
+  local original_context_config
+  local original_load
+
+  before_each(function()
+    original_context_config = vim.deepcopy(state.current_context_config)
+    original_load = context.load
+  end)
+
+  after_each(function()
+    state.current_context_config = original_context_config
+    context.load = original_load
+  end)
+
+  it('set_context updates state config for a supported key', function()
+    local load_called = false
+    context.load = function()
+      load_called = true
+    end
+
+    local enabled = context.set_context('current_file', false)
+
+    assert.is_false(enabled)
+    assert.is_false(state.current_context_config.current_file.enabled)
+    assert.is_true(load_called)
+  end)
+
+  it('toggle_context inverts the current value', function()
+    context.load = function() end
+    state.current_context_config = {
+      current_file = { enabled = false },
+    }
+
+    local enabled = context.toggle_context('current_file')
+
+    assert.is_true(enabled)
+    assert.is_true(state.current_context_config.current_file.enabled)
+  end)
+
+  it('set_context supports buffer and git_diff keys', function()
+    context.load = function() end
+
+    local enabled_buffer = context.set_context('buffer', true)
+    local enabled_git_diff = context.set_context('git_diff', true)
+
+    assert.is_true(enabled_buffer)
+    assert.is_true(enabled_git_diff)
+    assert.is_true(state.current_context_config.buffer.enabled)
+    assert.is_true(state.current_context_config.git_diff.enabled)
+  end)
+
+  it('returns error for unsupported keys', function()
+    context.load = function() end
+
+    local enabled = context.toggle_context('files')
+
+    assert.is_nil(enabled)
+  end)
+end)
+
 describe('get_diagnostics with chat context selections', function()
   local ChatContext
 


### PR DESCRIPTION
this would allow context toggles in keymaps and other user configs

I've been using this one in recent weeks and it's super convenient imo :)

```lua
keymap = {
    input_window = {
        ['<C-a>'] = {
            function()
                local enabled =
                    require('opencode.context').toggle_context('current_file')
                if enabled ~= nil then
                    vim.notify('current file context: ' .. (enabled and 'on' or 'off'))
                end
            end,
            desc = 'Toggle current file context',
            mode = { 'n', 'i' },
        }
    }
}
```