### PR TITLE
fix(session): prevent dispatch args leaking as parent_id in select_session

### DIFF
--- a/lua/opencode/commands/handlers/session.lua
+++ b/lua/opencode/commands/handlers/session.lua
@@ -441,7 +441,7 @@ M.command_defs = {
   },
   -- action name aliases for keymap compatibility
   open_input_new_session = { desc = 'Open input (new session)', execute = M.actions.open_input_new_session },
-  select_session         = { desc = 'Select session',           execute = M.actions.select_session },
+  select_session         = { desc = 'Select session',           execute = function() return M.actions.select_session() end },
   select_child_session   = { desc = 'Select child session',     execute = M.actions.select_child_session },
   rename_session         = { desc = 'Rename session',           execute = function(args) return M.actions.rename_session(nil, args[1]) end },
   undo = {


### PR DESCRIPTION
# Problem

After the commands refactor (#337), the dispatch layer calls all `execute` functions with the signature `execute(args, range)`. The `select_session` keymap alias was directly referencing `M.actions.select_session`, which interprets its first parameter as `parent_id`.

When triggered via keymap with no arguments, dispatch passes `{}` (empty args table) as the first argument. This causes `core.select_session` to filter sessions where `s.parentID == {}`, which never matches — every session is filtered out, and the user always sees "No child sessions found".

The `/sessions` slash command was unaffected because it routes through the `session` command handler, which calls `M.actions.select_session()` without arguments.

## Fix

Wrap the `execute` binding so dispatch args are not forwarded as `parent_id`, matching the pattern already used by `rename_session` on the adjacent line.
