### PR TITLE
fix(ui): disable statuscolumn in input window

### DIFF
--- a/lua/opencode/ui/input_window.lua
+++ b/lua/opencode/ui/input_window.lua
@@ -256,6 +256,7 @@ function M.setup(windows)
 
   window_options.set_buffer_option('filetype', 'opencode', windows.input_buf)
   window_options.set_window_option('winhighlight', config.ui.window_highlight, windows.input_win)
+  window_options.set_window_option('statuscolumn', '', windows.input_win)
 
   -- Apply user-configurable window options
   local win_opts = config.ui.input.win_options or {}


### PR DESCRIPTION
This PR updates the input buffer to clear the `statuscolumn`, ensuring it matches the behaviour of the output buffer.

Without this change, users with a configured `statuscolumn` may see visual artifacts in the status column of the input buffer.