### PR TITLE
fix(ui): disable colorcolumn in windows

### DIFF
--- a/lua/opencode/ui/input_window.lua
+++ b/lua/opencode/ui/input_window.lua
@@ -257,6 +257,7 @@ function M.setup(windows)
   window_options.set_buffer_option('filetype', 'opencode', windows.input_buf)
   window_options.set_window_option('winhighlight', config.ui.window_highlight, windows.input_win)
   window_options.set_window_option('statuscolumn', '', windows.input_win)
+  window_options.set_window_option('colorcolumn', '', windows.input_win)
 
   -- Apply user-configurable window options
   local win_opts = config.ui.input.win_options or {}

--- a/lua/opencode/ui/output_window.lua
+++ b/lua/opencode/ui/output_window.lua
@@ -193,6 +193,7 @@ function M.setup(windows)
   window_options.set_window_option('signcolumn', 'yes', windows.output_win, { save_original = true })
   window_options.set_window_option('list', false, windows.output_win, { save_original = true })
   window_options.set_window_option('statuscolumn', '', windows.output_win, { save_original = true })
+  window_options.set_window_option('colorcolumn', '', windows.output_win, { save_original = true })
 
   M.update_dimensions(windows)
   M.reset_scroll_tracking(windows.output_win)


### PR DESCRIPTION
Set `colorcolumn=''` for the input and output window. 

Here is an example of how the colour column shows up in the output buffer. I added red arrows to highlight where characters are marked through the `colorcolumn` setting.

<img width="527" height="461" alt="Screenshot 2026-04-15 at 16 47 03" src="https://github.com/user-attachments/assets/f617a1bd-5ded-44cc-89bc-59a50953fce2" />

With the fix:

<img width="527" height="461" alt="image" src="https://github.com/user-attachments/assets/3f8b983f-32a9-45d9-8be6-eca37dceeec8" />
