### PR TITLE
fix(session_picker): switch to remaining session when deleting active one

### DIFF
--- a/lua/opencode/ui/session_picker.lua
+++ b/lua/opencode/ui/session_picker.lua
@@ -56,12 +56,28 @@ function M.pick(sessions, callback)
 
         local sessions_to_delete = type(selected) == 'table' and selected.id == nil and selected or { selected }
 
-        for _, session in ipairs(sessions_to_delete) do
-          if state.active_session and state.active_session.id == session.id then
-            vim.notify('deleting current session, creating new session')
-            state.session.set_active(require('opencode.core').create_new_session():await())
-          end
+        local to_delete_ids = {}
+        for _, s in ipairs(sessions_to_delete) do
+          to_delete_ids[s.id] = true
+        end
 
+        local deleting_current = state.active_session and to_delete_ids[state.active_session.id] or false
+
+        if deleting_current then
+          local core = require('opencode.core')
+          local remaining = vim.tbl_filter(function(item)
+            return not to_delete_ids[item.id]
+          end, opts.items or {})
+
+          if #remaining > 0 then
+            core.switch_session(remaining[1].id):await()
+          else
+            vim.notify('deleting current session, creating new session')
+            state.session.set_active(core.create_new_session():await())
+          end
+        end
+
+        for _, session in ipairs(sessions_to_delete) do
           state.api_client:delete_session(session.id):catch(function(err)
             vim.schedule(function()
               vim.notify('Failed to delete session ' .. session.id .. ': ' .. vim.inspect(err), vim.log.levels.ERROR)


### PR DESCRIPTION
## Summary

Fix `<C-d>` in the session picker creating a new session when deleting the active one instead of switching to a remaining session.

## Problem

Deleting the active session always spawned a new session, even when other sessions existed. The user would land on an unexpected blank session, and the picker would show the leftover entries plus the freshly-created one. This was also inconsistent with deleting a non-active session, which simply removes the entry.

## Fix

The delete action now switches to the most recently updated remaining session via `core.switch_session`, and only falls back to `core.create_new_session` when no sessions remain.

## Behavior

- Active session deleted with others remaining → switch to most recent remaining.
- Active session deleted when it's the only one → create new (unchanged).
- Non-active session deleted → unchanged.

