### PR TITLE
fix(ui): avoid extraneous empty lines for compacted headers

### DIFF
--- a/lua/opencode/ui/formatter.lua
+++ b/lua/opencode/ui/formatter.lua
@@ -280,7 +280,12 @@ function M.format_message_header(message, previous_message)
     M._format_callout(output, 'ERROR', error_message)
   end
 
-  output:add_line('')
+  local hidden_same_mode_assistant_header = role == 'assistant' and header_style == 'hidden' and same_mode_as_previous
+
+  if not hidden_same_mode_assistant_header then
+    output:add_line('')
+  end
+
   return output
 end
 

--- a/tests/unit/formatter_spec.lua
+++ b/tests/unit/formatter_spec.lua
@@ -437,8 +437,62 @@ describe('formatter', function()
       parts = {},
     })
 
-    assert.are.same({ '' }, output.lines)
+    assert.are.same({}, output.lines)
     assert.is_nil(output.extmarks[0])
+  end)
+
+  it('does not add a spacing-only block for hidden same-mode assistant messages', function()
+    config.setup({
+      ui = {
+        output = {
+          compact_assistant_headers = 'hidden',
+        },
+      },
+    })
+
+    local previous_message = {
+      info = {
+        id = 'msg_prev',
+        role = 'assistant',
+        sessionID = 'ses_1',
+        mode = 'build',
+      },
+      parts = {},
+    }
+
+    local current_message = {
+      info = {
+        id = 'msg_current',
+        role = 'assistant',
+        sessionID = 'ses_1',
+        mode = 'build',
+      },
+      parts = {},
+    }
+
+    local previous_part = formatter.format_part({
+      id = 'prt_prev',
+      type = 'text',
+      text = 'First reply',
+      messageID = 'msg_prev',
+      sessionID = 'ses_1',
+    }, previous_message, true)
+
+    local header = formatter.format_message_header(current_message, previous_message)
+    local current_part = formatter.format_part({
+      id = 'prt_current',
+      type = 'text',
+      text = 'Second reply',
+      messageID = 'msg_current',
+      sessionID = 'ses_1',
+    }, current_message, true)
+
+    local combined_lines = {}
+    vim.list_extend(combined_lines, previous_part.lines)
+    vim.list_extend(combined_lines, header.lines)
+    vim.list_extend(combined_lines, current_part.lines)
+
+    assert.are.same({ 'First reply', '', 'Second reply', '' }, combined_lines)
   end)
 
   it('keeps full assistant headers when the mode changes', function()


### PR DESCRIPTION
There is an extraneous empty line in place of a header line when compaction is on.

I am proposing removing this extra line, assuming that it is indeed extraneous and not a visual cue 😄 

## Before

I marked the sections in question with a red line:

<img width="660" height="553" alt="Screenshot 2026-04-24 at 13 15 15" src="https://github.com/user-attachments/assets/e102a996-eda7-43df-b7e0-a064144daf55" />

## After

Note the gaps have become smaller as the extraneous empty line is removed.

<img width="660" height="553" alt="Screenshot 2026-04-24 at 13 19 15" src="https://github.com/user-attachments/assets/fb528721-172c-426d-8862-7afbd06b41e5" />
