### PR TITLE
fix: await send_message chain to eliminate flaky user_message_count test

### DIFF
--- a/lua/opencode/services/messaging.lua
+++ b/lua/opencode/services/messaging.lua
@@ -83,6 +83,7 @@ M.send_message = Promise.async(function(prompt, opts)
       update_sent_message_count(-1)
       session_runtime.cancel():await()
     end)
+    :await()
 end)
 
 ---@param prompt string

--- a/tests/unit/services_messaging_spec.lua
+++ b/tests/unit/services_messaging_spec.lua
@@ -78,7 +78,6 @@ describe('opencode.services.messaging', function()
 
     local count_before = state.user_message_count['sess1'] or 0
     local count_during = nil
-    local count_after = nil
 
     local orig = state.api_client.create_message
     state.api_client.create_message = function(_, sid, params)
@@ -90,12 +89,9 @@ describe('opencode.services.messaging', function()
       })
     end
 
-    messaging.send_message('hello world')
+    messaging.send_message('hello world'):wait()
 
-    vim.wait(50, function()
-      count_after = state.user_message_count['sess1'] or 0
-      return count_after == 0
-    end)
+    local count_after = state.user_message_count['sess1'] or 0
 
     assert.equal(0, count_before)
     assert.equal(1, count_during)
@@ -111,7 +107,6 @@ describe('opencode.services.messaging', function()
 
     local count_before = state.user_message_count['sess1'] or 0
     local count_during = nil
-    local count_after = nil
 
     local orig = state.api_client.create_message
     state.api_client.create_message = function(_, sid, params)
@@ -120,14 +115,11 @@ describe('opencode.services.messaging', function()
     end
 
     local orig_cancel = session_runtime.cancel
-    stub(session_runtime, 'cancel')
+    stub(session_runtime, 'cancel').returns(Promise.new():resolve(nil))
 
-    messaging.send_message('hello world')
+    messaging.send_message('hello world'):wait()
 
-    vim.wait(50, function()
-      count_after = state.user_message_count['sess1'] or 0
-      return count_after == 0
-    end)
+    local count_after = state.user_message_count['sess1'] or 0
 
     assert.equal(0, count_before)
     assert.equal(1, count_during)


### PR DESCRIPTION
## Summary

- Await the `.and_then`/`.catch` chain in `send_message` so the returned promise reflects the full operation lifecycle, not just the setup phase
- Replace flaky `vim.wait(50ms)` polling in tests with deterministic `:wait()` calls on the promise

## Problem

The `increments and decrements user_message_count correctly` test was consistently failing on `macos-latest, v0.11.4` CI ([example on main](https://github.com/sudo-tee/opencode.nvim/actions/runs/25012018331)). `send_message` fired off the `.and_then`/`.catch` chain without awaiting it. Since `create_message` returned an already-resolved promise, the `.and_then` callback was deferred via `vim.schedule_wrap`. The test used `vim.wait(50, ...)` to poll for the count decrement, which was not reliably sufficient on macOS runners.

## Fix

`send_message` is already `Promise.async` (runs in a coroutine), so adding `:await()` at the end of the chain is the correct fix — it makes the function wait for the full send lifecycle before resolving. The tests then use `:wait()` on the returned promise instead of polling.