### PR TITLE
fix(ui): prevent re-applying style='minimal' on float UI

### DIFF
--- a/lua/opencode/ui/float_layout.lua
+++ b/lua/opencode/ui/float_layout.lua
@@ -71,7 +71,6 @@ local function base_config(windows)
     height = height,
     row = resolve_position(float.row, vim.o.lines, height),
     col = resolve_position(float.col, vim.o.columns, width),
-    style = 'minimal',
     border = float.border,
   }
 end
@@ -114,6 +113,7 @@ end
 ---@param win_config vim.api.keyset.win_config
 ---@return integer
 function M.open_win(buf, enter, win_config)
+  win_config = vim.tbl_deep_extend('force', win_config, { style = 'minimal' })
   local win = vim.api.nvim_open_win(buf, enter, win_config)
   local float = config.ui.float or {}
   for opt, value in pairs(float.opts or {}) do


### PR DESCRIPTION
Fixes a bug where the float layout re-applies `style = 'minimal'` after `update_dimensions`, resetting window-local options that were explicitly set by `output_window.setup()`.

## Problem

When using `position = "float"`, window options like `signcolumn = 'yes'` and `foldcolumn = '1'` (set by `output_window.setup()`) get reset to `'auto'` and `'0'`. This happens because:

1. `output_window.setup()` sets `signcolumn = 'yes'` and `foldcolumn = '1'`
2. `update_dimensions()` is called immediately after
3. `float_layout.update()` → `nvim_win_set_config()` re-applies `style = 'minimal'` from `base_config()`
4. `style = 'minimal'` resets `signcolumn` and `foldcolumn` back to their minimal defaults

This causes the floating window to lose its left gutter, unlike the split layout which correctly retains these options.

<img width="2441" height="871" alt="image" src="https://github.com/user-attachments/assets/31d0c3e8-9a1f-46e4-b474-56552c72c2a7" />

## Fix

Move `style = 'minimal'` from `base_config()` into `open_win()` so it only applies during the initial `nvim_open_win()` call, not during subsequent `nvim_win_set_config()` updates.

<img width="2442" height="874" alt="image" src="https://github.com/user-attachments/assets/8ff45ccd-7d23-48fd-b30c-d8c2c0195f79" />
