### PR TITLE
perf(renderer): avoid server round-trip on display toggles and incremental fold updates

### DIFF
--- a/lua/opencode/commands/handlers/workflow.lua
+++ b/lua/opencode/commands/handlers/workflow.lua
@@ -273,14 +273,14 @@ function M.actions.toggle_tool_output()
   local action_text = config.ui.output.tools.show_output and 'Hiding' or 'Showing'
   vim.notify(action_text .. ' tool output display', vim.log.levels.INFO)
   config.values.ui.output.tools.show_output = not config.ui.output.tools.show_output
-  ui.render_output()
+  ui.render_output_from_cache()
 end
 
 function M.actions.toggle_reasoning_output()
   local action_text = config.ui.output.tools.show_reasoning_output and 'Hiding' or 'Showing'
   vim.notify(action_text .. ' reasoning output display', vim.log.levels.INFO)
   config.values.ui.output.tools.show_reasoning_output = not config.ui.output.tools.show_reasoning_output
-  ui.render_output()
+  ui.render_output_from_cache()
 end
 
 local original_max_messages = config.ui.output.max_messages
@@ -297,7 +297,7 @@ function M.actions.toggle_max_messages()
   local val_text = next_val == nil and 'none' or tostring(next_val)
   vim.notify(action_text .. ' message limit to ' .. val_text, vim.log.levels.INFO)
   config.values.ui.output.max_messages = next_val
-  ui.render_output()
+  ui.render_output_from_cache()
 end
 
 M.actions.review = Promise.async(function(args)

--- a/lua/opencode/ui/renderer.lua
+++ b/lua/opencode/ui/renderer.lua
@@ -316,11 +316,15 @@ end
 ---Render all messages and parts from session_data into the output buffer
 ---Called after a full session fetch or when revert state changes
 ---@param session_data OpencodeMessage[]
----@param opts? { restore_model_from_messages?: boolean }
+---@param opts? { restore_model_from_messages?: boolean, skip_deepcopy?: boolean }
 function M._render_full_session_data(session_data, opts)
   opts = opts or {}
   M.reset()
-  state.renderer.set_messages(vim.deepcopy(session_data or {}))
+  if opts.skip_deepcopy then
+    state.renderer.set_messages(session_data or {})
+  else
+    state.renderer.set_messages(vim.deepcopy(session_data or {}))
+  end
 
   if not state.active_session or not state.messages then
     return
@@ -399,6 +403,7 @@ function M.render_from_cache(session_data)
   end
   M._render_full_session_data(session_data, {
     restore_model_from_messages = true,
+    skip_deepcopy = true,
   })
   local active_session = state.active_session
   if active_session and active_session.id then

--- a/lua/opencode/ui/renderer.lua
+++ b/lua/opencode/ui/renderer.lua
@@ -316,15 +316,11 @@ end
 ---Render all messages and parts from session_data into the output buffer
 ---Called after a full session fetch or when revert state changes
 ---@param session_data OpencodeMessage[]
----@param opts? { restore_model_from_messages?: boolean, skip_deepcopy?: boolean }
+---@param opts? { restore_model_from_messages?: boolean }
 function M._render_full_session_data(session_data, opts)
   opts = opts or {}
   M.reset()
-  if opts.skip_deepcopy then
-    state.renderer.set_messages(session_data or {})
-  else
-    state.renderer.set_messages(vim.deepcopy(session_data or {}))
-  end
+  state.renderer.set_messages(session_data or {})
 
   if not state.active_session or not state.messages then
     return
@@ -403,7 +399,6 @@ function M.render_from_cache(session_data)
   end
   M._render_full_session_data(session_data, {
     restore_model_from_messages = true,
-    skip_deepcopy = true,
   })
   local active_session = state.active_session
   if active_session and active_session.id then

--- a/lua/opencode/ui/renderer.lua
+++ b/lua/opencode/ui/renderer.lua
@@ -390,6 +390,23 @@ function M._render_full_session_data(session_data, opts)
   end
 end
 
+---Re-render from cached session data without a server round-trip.
+---Used for display-only changes (toggle folds, max_messages, etc.)
+---@param session_data OpencodeMessage[]
+function M.render_from_cache(session_data)
+  if not output_window.mounted() or not state.api_client then
+    return
+  end
+  M._render_full_session_data(session_data, {
+    restore_model_from_messages = true,
+  })
+  local active_session = state.active_session
+  if active_session and active_session.id then
+    require('opencode.ui.question_window').restore_pending_question(active_session.id)
+    permission_window.restore_pending_permissions(active_session.id)
+  end
+end
+
 ---Fetch the active session from the server and render it
 ---@return Promise<OpencodeMessage[]>
 function M.render_full_session()

--- a/lua/opencode/ui/renderer/buffer.lua
+++ b/lua/opencode/ui/renderer/buffer.lua
@@ -657,6 +657,15 @@ function M.set_all_folds()
   output_window.set_folds(all_folds)
 end
 
+local function folds_equal(a, b)
+  if not a or not b then return false end
+  if #a ~= #b then return false end
+  for i = 1, #a do
+    if a[i].from ~= b[i].from or a[i].to ~= b[i].to then return false end
+  end
+  return true
+end
+
 ---Update folds for a single part during streaming, avoiding a full rebuild.
 ---@param part_id string
 function M.update_part_folds(part_id)
@@ -679,41 +688,17 @@ function M.update_part_folds(part_id)
     })
   end
 
-  local old_folds = ctx.part_folds[part_id]
-  if old_folds and #old_folds == #new_folds then
-    local same = true
-    for i = 1, #new_folds do
-      if new_folds[i].from ~= old_folds[i].from or new_folds[i].to ~= old_folds[i].to then
-        same = false
-        break
-      end
-    end
-    if same then
-      return
-    end
-  end
-
-  local new_global = {}
-  local found = false
-  for pid, pf in pairs(ctx.part_folds) do
-    if pid == part_id then
-      found = true
-      for _, nf in ipairs(new_folds) do
-        table.insert(new_global, nf)
-      end
-    else
-      for _, of in ipairs(pf) do
-        table.insert(new_global, of)
-      end
-    end
-  end
-  if not found then
-    for _, nf in ipairs(new_folds) do
-      table.insert(new_global, nf)
-    end
+  if folds_equal(ctx.part_folds[part_id], new_folds) then
+    return
   end
 
   ctx.part_folds[part_id] = new_folds
+  local new_global = {}
+  for _, pf in pairs(ctx.part_folds) do
+    for _, f in ipairs(pf) do
+      table.insert(new_global, f)
+    end
+  end
   ctx.global_folds = new_global
   output_window.set_folds(new_global)
 end

--- a/lua/opencode/ui/renderer/buffer.lua
+++ b/lua/opencode/ui/renderer/buffer.lua
@@ -699,6 +699,7 @@ function M.update_part_folds(part_id)
       table.insert(new_global, f)
     end
   end
+  table.sort(new_global, function(a, b) return a.from < b.from end)
   ctx.global_folds = new_global
   output_window.set_folds(new_global)
 end

--- a/lua/opencode/ui/renderer/buffer.lua
+++ b/lua/opencode/ui/renderer/buffer.lua
@@ -600,12 +600,12 @@ function M.upsert_part_now(part_id, message_id, formatted_data, previous_formatt
     set_part_extmark_state(part_id, formatted_data)
 
     if formatted_data.fold_ranges and #formatted_data.fold_ranges > 0 then
-      M.set_all_folds()
+      M.update_part_folds(part_id)
     end
 
     return true
   end
-  
+
 local insert_at = get_part_insertion_line(part_id, message_id)
   if not insert_at then
     return false
@@ -635,20 +635,87 @@ end
 
 function M.set_all_folds()
   local all_folds = {}
+  ctx.part_folds = {}
   for part_id_iter, data in pairs(ctx.formatted_parts) do
     if data.fold_ranges then
       local cached_part = ctx.render_state:get_part(part_id_iter)
       if cached_part and cached_part.line_start then
+        local part_abs_folds = {}
         for _, f in ipairs(data.fold_ranges) do
-          table.insert(all_folds, {
+          local abs = {
             from = cached_part.line_start + f.from - 1,
             to = cached_part.line_start + f.to - 1,
-          })
+          }
+          table.insert(part_abs_folds, abs)
+          table.insert(all_folds, abs)
         end
+        ctx.part_folds[part_id_iter] = part_abs_folds
       end
     end
   end
+  ctx.global_folds = all_folds
   output_window.set_folds(all_folds)
+end
+
+---Update folds for a single part during streaming, avoiding a full rebuild.
+---@param part_id string
+function M.update_part_folds(part_id)
+  local formatted_data = ctx.formatted_parts[part_id]
+  if not formatted_data or not formatted_data.fold_ranges then
+    ctx.part_folds[part_id] = nil
+    M.set_all_folds()
+    return
+  end
+  local cached_part = ctx.render_state:get_part(part_id)
+  if not cached_part or not cached_part.line_start then
+    return
+  end
+
+  local new_folds = {}
+  for _, f in ipairs(formatted_data.fold_ranges) do
+    table.insert(new_folds, {
+      from = cached_part.line_start + f.from - 1,
+      to = cached_part.line_start + f.to - 1,
+    })
+  end
+
+  local old_folds = ctx.part_folds[part_id]
+  if old_folds and #old_folds == #new_folds then
+    local same = true
+    for i = 1, #new_folds do
+      if new_folds[i].from ~= old_folds[i].from or new_folds[i].to ~= old_folds[i].to then
+        same = false
+        break
+      end
+    end
+    if same then
+      return
+    end
+  end
+
+  local new_global = {}
+  local found = false
+  for pid, pf in pairs(ctx.part_folds) do
+    if pid == part_id then
+      found = true
+      for _, nf in ipairs(new_folds) do
+        table.insert(new_global, nf)
+      end
+    else
+      for _, of in ipairs(pf) do
+        table.insert(new_global, of)
+      end
+    end
+  end
+  if not found then
+    for _, nf in ipairs(new_folds) do
+      table.insert(new_global, nf)
+    end
+  end
+
+  ctx.part_folds[part_id] = new_folds
+  ctx.global_folds = new_global
+  output_window.set_folds(new_global)
 end
 
 

--- a/lua/opencode/ui/renderer/buffer.lua
+++ b/lua/opencode/ui/renderer/buffer.lua
@@ -743,6 +743,9 @@ function M.append_part_now(part_id, extra_lines, extra_extmarks, previous_format
     apply_part_actions(part_id, formatted_data, cached.line_start)
     apply_extmarks(previous_formatted, formatted_data, cached.line_start, old_line_end, new_line_end)
     set_part_extmark_state(part_id, formatted_data)
+    if formatted_data.fold_ranges then
+      M.update_part_folds(part_id)
+    end
   elseif has_extmarks(extra_extmarks) then
     output_window.set_extmarks(extra_extmarks, insert_at)
   end

--- a/lua/opencode/ui/renderer/ctx.lua
+++ b/lua/opencode/ui/renderer/ctx.lua
@@ -29,6 +29,10 @@ local ctx = {
   bulk_buffer_lines = {},
   bulk_extmarks_by_line = {},
   bulk_folds = {},
+  ---@type {from: number, to: number}[]
+  global_folds = {},
+  ---@type table<string, {from: number, to: number}[]>
+  part_folds = {},
 }
 
 ---Reset all renderer caches and pending state.
@@ -50,6 +54,8 @@ function ctx:reset()
   }
   self.flush_scheduled = false
   self.markdown_render_scheduled = false
+  self.global_folds = {}
+  self.part_folds = {}
   self:bulk_reset()
 end
 

--- a/lua/opencode/ui/ui.lua
+++ b/lua/opencode/ui/ui.lua
@@ -484,6 +484,19 @@ function M.clear_output()
   -- state.restore_points = {}
 end
 
+---Re-render the output buffer from cached session data, avoiding a server round-trip.
+---Used for display-only toggles (show_reasoning_output, show_output, max_messages).
+---Falls back to render_output() if no cached messages are available.
+---@param opts? {force_scroll?: boolean}
+function M.render_output_from_cache(opts)
+  local session_data = state.messages
+  if not session_data or not next(session_data) then
+    M.render_output(false, opts)
+    return
+  end
+  renderer.render_from_cache(session_data)
+end
+
 ---Force a full rerender of the output buffer. Should be done synchronously if
 ---called before submitting input or doing something that might generate events
 ---from opencode

--- a/tests/unit/renderer_buffer_spec.lua
+++ b/tests/unit/renderer_buffer_spec.lua
@@ -126,3 +126,67 @@ describe('renderer.buffer extmarks', function()
     assert_called_before(call_order, 'clear_extmarks', 'set_lines')
   end)
 end)
+
+describe('update_part_folds', function()
+  local set_folds_stub
+
+  before_each(function()
+    ctx:reset()
+    set_folds_stub = stub(output_window, 'set_folds')
+    ctx.global_folds = {}
+    ctx.part_folds = {}
+  end)
+
+  after_each(function()
+    set_folds_stub:revert()
+    ctx:reset()
+  end)
+
+  it('computes absolute fold ranges for a single part', function()
+    ctx.formatted_parts['part_a'] = {
+      lines = { 'title', '', 'content', 'more' },
+      fold_ranges = { { from = 1, to = 4 } },
+    }
+    ctx.render_state:set_part({ id = 'part_a', messageID = 'msg_1', type = 'text' }, 10, 14)
+
+    buffer.update_part_folds('part_a')
+
+    assert.stub(set_folds_stub).was_called_with({
+      { from = 10, to = 13 },
+    })
+  end)
+
+  it('skips set_folds when fold ranges have not changed', function()
+    ctx.formatted_parts['part_a'] = {
+      lines = { 'title', '', 'content', 'more' },
+      fold_ranges = { { from = 1, to = 4 } },
+    }
+    ctx.render_state:set_part({ id = 'part_a', messageID = 'msg_1', type = 'text' }, 10, 14)
+
+    buffer.update_part_folds('part_a')
+    set_folds_stub:clear()
+
+    buffer.update_part_folds('part_a')
+
+    assert.stub(set_folds_stub).was_not_called()
+  end)
+
+  it('merges existing folds from other parts', function()
+    ctx.part_folds['part_b'] = { { from = 5, to = 8 } }
+    ctx.global_folds = { { from = 5, to = 8 } }
+
+    ctx.formatted_parts['part_a'] = {
+      lines = { 'title', '', 'content', 'more' },
+      fold_ranges = { { from = 1, to = 4 } },
+    }
+    ctx.render_state:set_part({ id = 'part_a', messageID = 'msg_1', type = 'text' }, 10, 14)
+
+    buffer.update_part_folds('part_a')
+
+    assert.stub(set_folds_stub).was_called()
+    assert.stub(set_folds_stub).was_called_with({
+      { from = 5, to = 8 },
+      { from = 10, to = 13 },
+    })
+  end)
+end)

--- a/tests/unit/renderer_buffer_spec.lua
+++ b/tests/unit/renderer_buffer_spec.lua
@@ -183,7 +183,6 @@ describe('update_part_folds', function()
 
     buffer.update_part_folds('part_a')
 
-    assert.stub(set_folds_stub).was_called()
     assert.stub(set_folds_stub).was_called_with({
       { from = 5, to = 8 },
       { from = 10, to = 13 },


### PR DESCRIPTION
## Summary

Three performance fixes for the renderer, plus one bug fix for fold ranges not tracking content during streaming.

## Changes

### 1. Cache-based re-render for display toggles
`toggle_reasoning_output`, `toggle_tool_output`, and `toggle_max_messages` now re-render from `state.messages` in memory instead of fetching the full session from the server. A new `render_from_cache()` path skips `fetch_session()` entirely, making toggles instant (no network round-trip).

### 2. Incremental fold updates during streaming
`update_part_folds(part_id)` replaces `set_all_folds()` in the streaming update path. Instead of rebuilding the entire fold list from all parts on every chunk, it only updates the fold ranges for the single part that changed, then merges with the cached per-part fold list.

### 3. Remove unnecessary `vim.deepcopy`
`_render_full_session_data` was deep-copying the entire messages table on every re-render. All callers pass tables that are either fresh API responses (no other references) or are used synchronously (no concurrent mutation window). The deep copy served no actual protection -- event handlers mutate `state.messages` in-place anyway after storage.

### 4. Fix fold range not updating during append-only streaming
`append_part_now()` wrote new lines but never updated the part's fold range. During streaming, the fold's `to` boundary stayed at the initial value while content grew, causing new content to appear outside the fold. Now calls `update_part_folds()` after appending.

## Verification

Tested on Windows + nvy + Neovim -- the lag that was present when toggling reasoning/tool output visibility and during streaming of large sessions is almost completely gone.

## Notes

- This PR was AI-generated and requires careful review.
- The `render_from_cache` path is safe because it executes synchronously with no yield points -- `_render_full_session_data` is a single contiguous call.
- The incremental fold cache (`ctx.part_folds`, `ctx.global_folds`) is cleared on `ctx:reset()` (full session re-render) and rebuilt from scratch via `set_all_folds()`. No stale cache issues.

Closes #322 (partially)
