### PR TITLE
fix(session): restore subagent mode from messages

### DIFF
--- a/lua/opencode/services/agent_model.lua
+++ b/lua/opencode/services/agent_model.lua
@@ -174,7 +174,15 @@ M.initialize_current_model = Promise.async(function(opts)
           state.model.set_model(model_str)
         end
         if msg.info.mode and state.current_mode ~= msg.info.mode then
-          state.model.set_mode(msg.info.mode)
+          local active_session = state.active_session
+          local should_restore_mode = active_session and active_session.parentID
+          if not should_restore_mode then
+            local available_agents = config_file.get_opencode_agents():await()
+            should_restore_mode = vim.tbl_contains(available_agents, msg.info.mode)
+          end
+          if should_restore_mode then
+            state.model.set_mode(msg.info.mode)
+          end
         end
         return state.current_model
       end

--- a/lua/opencode/services/agent_model.lua
+++ b/lua/opencode/services/agent_model.lua
@@ -174,10 +174,7 @@ M.initialize_current_model = Promise.async(function(opts)
           state.model.set_model(model_str)
         end
         if msg.info.mode and state.current_mode ~= msg.info.mode then
-          local available_agents = config_file.get_opencode_agents():await()
-          if vim.tbl_contains(available_agents, msg.info.mode) then
-            state.model.set_mode(msg.info.mode)
-          end
+          state.model.set_mode(msg.info.mode)
         end
         return state.current_model
       end

--- a/tests/unit/services_agent_model_spec.lua
+++ b/tests/unit/services_agent_model_spec.lua
@@ -145,8 +145,6 @@ describe('opencode.services.agent_model', function()
     state.model.set_model('openai/gpt-4.1')
     state.model.set_mode('plan')
 
-    stub(config_file, 'get_opencode_agents').returns(Promise.new():resolve({ 'plan', 'build' }))
-
     state.renderer.set_messages({
       {
         info = {
@@ -163,15 +161,11 @@ describe('opencode.services.agent_model', function()
     assert.equal('anthropic/claude-3-opus', model)
     assert.equal('anthropic/claude-3-opus', state.current_model)
     assert.equal('build', state.current_mode)
-
-    config_file.get_opencode_agents:revert()
   end)
 
-  it('does not restore mode to a hidden agent from messages', function()
+  it('restores mode from messages even if the agent is hidden', function()
     state.model.set_model('openai/gpt-4.1')
     state.model.set_mode('build')
-
-    stub(config_file, 'get_opencode_agents').returns(Promise.new():resolve({ 'plan', 'build' }))
 
     state.renderer.set_messages({
       {
@@ -188,8 +182,6 @@ describe('opencode.services.agent_model', function()
 
     assert.equal('anthropic/claude-3-opus', model)
     assert.equal('anthropic/claude-3-opus', state.current_model)
-    assert.equal('build', state.current_mode)
-
-    config_file.get_opencode_agents:revert()
+    assert.equal('hidden-xyz', state.current_mode)
   end)
 end)

--- a/tests/unit/services_agent_model_spec.lua
+++ b/tests/unit/services_agent_model_spec.lua
@@ -144,6 +144,7 @@ describe('opencode.services.agent_model', function()
   it('restores the latest session model and mode when explicitly requested', function()
     state.model.set_model('openai/gpt-4.1')
     state.model.set_mode('plan')
+    stub(config_file, 'get_opencode_agents').returns(Promise.new():resolve({ 'plan', 'build' }))
 
     state.renderer.set_messages({
       {
@@ -161,11 +162,14 @@ describe('opencode.services.agent_model', function()
     assert.equal('anthropic/claude-3-opus', model)
     assert.equal('anthropic/claude-3-opus', state.current_model)
     assert.equal('build', state.current_mode)
+
+    config_file.get_opencode_agents:revert()
   end)
 
-  it('restores mode from messages even if the agent is hidden', function()
+  it('restores hidden mode from messages for child sessions', function()
     state.model.set_model('openai/gpt-4.1')
     state.model.set_mode('build')
+    state.session.set_active({ id = 'child', parentID = 'parent' })
 
     state.renderer.set_messages({
       {
@@ -183,5 +187,34 @@ describe('opencode.services.agent_model', function()
     assert.equal('anthropic/claude-3-opus', model)
     assert.equal('anthropic/claude-3-opus', state.current_model)
     assert.equal('hidden-xyz', state.current_mode)
+
+    state.session.clear_active()
+  end)
+
+  it('does not restore hidden mode from messages for primary sessions', function()
+    state.model.set_model('openai/gpt-4.1')
+    state.model.set_mode('build')
+    state.session.set_active({ id = 'primary' })
+    stub(config_file, 'get_opencode_agents').returns(Promise.new():resolve({ 'plan', 'build' }))
+
+    state.renderer.set_messages({
+      {
+        info = {
+          id = 'm1',
+          providerID = 'anthropic',
+          modelID = 'claude-3-opus',
+          mode = 'hidden-xyz',
+        },
+      },
+    })
+
+    local model = agent_model.initialize_current_model({ restore_from_messages = true }):wait()
+
+    assert.equal('anthropic/claude-3-opus', model)
+    assert.equal('anthropic/claude-3-opus', state.current_model)
+    assert.equal('build', state.current_mode)
+
+    config_file.get_opencode_agents:revert()
+    state.session.clear_active()
   end)
 end)


### PR DESCRIPTION
Hidden subagents are filtered out of the visible primary-agent list so primary agents cannot discover them by default. That visibility rule should not affect restoring an existing session's agent type.

When restoring a session, the tabbar/footer and subsequent message routing should use the agent type recorded on the session messages. Filtering msg.info.mode through the visible primary-agent list caused hidden subagent sessions to keep a stale primary mode in state.current_mode.