### PR TITLE
fix(session-picker): fix fzf-lua preview gutter and list entry layout

### DIFF
--- a/lua/opencode/ui/base_picker.lua
+++ b/lua/opencode/ui/base_picker.lua
@@ -515,6 +515,17 @@ local function fzf_ui(opts)
   local fzf_config = create_fzf_config()
   fzf_config.actions = actions_config
 
+  -- When a preview pane is active, fzf-lua splits the window (default
+  -- right:60% preview, left:40% list). Narrow opts.width so that the
+  -- format function produces entries sized for the list pane, not the
+  -- full window. The format closure reads opts.width on each call.
+  local has_preview = opts.preview and opts.preview ~= 'none' and opts.preview ~= false
+  if has_preview and opts.width then
+    local window_cols = opts.width + 8
+    -- list pane ≈ 40% of the window, minus a small border/padding allowance
+    opts.width = math.floor(window_cols * 0.4) - 4
+  end
+
   fzf_lua.fzf_exec(create_finder(), fzf_config)
 end
 

--- a/lua/opencode/ui/session_picker.lua
+++ b/lua/opencode/ui/session_picker.lua
@@ -31,9 +31,8 @@ end
 ---@param session Session object
 ---@return PickerItem
 function format_session_item(session, width)
-  local debug_text = 'ID: ' .. (session.id or 'N/A')
   local updated_time = (session.time and session.time.updated) or 'N/A'
-  return base_picker.create_time_picker_item(session.title, updated_time, debug_text, width)
+  return base_picker.create_time_picker_item(session.title, updated_time, nil, width)
 end
 
 --- Normalize message order to oldest-first (chronological)
@@ -195,10 +194,16 @@ local function render_preview_buffer(target, formatted)
   pcall(vim.api.nvim_buf_clear_namespace, bufnr, output_window.namespace, 0, -1)
   output_window.apply_extmarks(bufnr, formatted.extmarks)
 
-  -- Apply folds (window-local operation)
-    target:with_window(function()
+  -- Configure preview window to match the main output window's gutter.
+  -- The formatter places vertical border extmarks at virt_text_win_col = -3
+  -- which requires a 3-column gutter (signcolumn=yes + foldcolumn=1) so
+  -- the border renders in the gutter instead of overlaying column 0 of text.
+  target:with_window(function()
       vim.api.nvim_set_option_value('number', false, { win = 0 })
       vim.api.nvim_set_option_value('relativenumber', false, { win = 0 })
+      vim.api.nvim_set_option_value('signcolumn', 'yes', { win = 0 })
+      vim.api.nvim_set_option_value('foldcolumn', '1', { win = 0 })
+      vim.api.nvim_set_option_value('statuscolumn', '', { win = 0 })
       vim.api.nvim_set_option_value('foldmethod', 'manual', { win = 0 })
     vim.cmd('silent! normal! zE') -- clear existing manual folds
     local line_count = vim.api.nvim_buf_line_count(bufnr)


### PR DESCRIPTION
## Issue

The session picker message preview (#398) has rendering issues specific to fzf-lua:

1. **First column obscured in preview pane** — The formatter renders vertical border extmarks at `virt_text_win_col = -3`, relying on the main output window's 3-column gutter (`signcolumn='yes'` + `foldcolumn='1'`). The fzf-lua preview window has zero gutter (`set_style_minimal` sets `signcolumn='no'`, `foldcolumn='0'`), so the border overlay lands on column 0 of the text area, obscuring the first column of every bordered line.

2. **Time column pushed off-screen** — Entries are formatted to @`opts.width` (e.g. 100 columns), but fzf-lua's preview split leaves only ~40% of the window for the list pane (~43 columns). The right-aligned time column renders beyond the visible area.

3. **Session IDs add clutter** — The list entries included session IDs that consumed layout space without adding value. IDs are already visible in the preview pane when a session is selected.

## Solution

Match the preview window's gutter configuration to the main output window so the formatter's extmarks render correctly. Adjust the format width to fit the actual list pane when a preview split is active. Drop session IDs from list entries since title + datetime is sufficient for identification.

## Changes

- **Preview window gutter** (@`session_picker.lua`) — Set `signcolumn='yes'`, `foldcolumn='1'`, and `statuscolumn=''` in `render_preview_buffer` to provide the 3-column gutter that the formatter's `virt_text_win_col = -3` border extmarks target.

- **List entry width with preview** (@`base_picker.lua`) — After building the fzf config (which retains the full @`winopts.width`), narrow `opts.width` to the list pane width (~40% of the window minus border padding) when a preview pane is active. The format function closure reads `opts.width` on each call, so entries are sized to fit.

- **Session picker entries** (`session_picker.lua`) — Remove session ID from `format_session_item`. The picker now shows title + datetime only.
