### PR TITLE
fix(picker): support relative and opt-out picker_width values

### DIFF
--- a/lua/opencode/model_picker.lua
+++ b/lua/opencode/model_picker.lua
@@ -87,6 +87,7 @@ function M.select(cb)
   base_picker.pick({
     title = 'Select model',
     items = models,
+    width = config.ui.picker_width,
     layout_opts = config.ui.picker,
     format_fn = function(item, width)
       local icon = item.icon or ''

--- a/lua/opencode/types.lua
+++ b/lua/opencode/types.lua
@@ -208,7 +208,7 @@
 ---@field persist_state boolean
 ---@field zoom_width number
 ---@field float OpencodeUIFloatConfig
----@field picker_width number|nil # Default width for all pickers (nil uses current window width)
+---@field picker_width number|false|nil # Width for pickers. 0<w<=1 = fraction of screen; >1 = absolute columns; false = use picker backend defaults.
 ---@field display_model boolean
 ---@field display_context_size boolean
 ---@field display_cost boolean

--- a/lua/opencode/ui/base_picker.lua
+++ b/lua/opencode/ui/base_picker.lua
@@ -855,9 +855,33 @@ function M.pick(opts)
     opts.width = math.floor(vim.o.columns * opts.width)
   end
 
+  -- When width is nil (picker_width = false or unset), derive a content width
+  -- from the picker backend's default window size so format functions can
+  -- produce correctly-sized output that fills the backend's content area.
+  local format_width = opts.width
+  if not format_width then
+    if picker_type == 'fzf' then
+      -- Read fzf-lua's effective winopts.width (respects user customization).
+      local fzf_win_width = 0.8
+      local ok, fzf_config = pcall(require, 'fzf-lua.config')
+      if ok and fzf_config and fzf_config.globals and fzf_config.globals.winopts then
+        fzf_win_width = fzf_config.globals.winopts.width or fzf_win_width
+      end
+      -- Resolve fraction to absolute columns
+      if fzf_win_width > 0 and fzf_win_width <= 1 then
+        fzf_win_width = math.floor(vim.o.columns * fzf_win_width)
+      end
+      -- Subtract the same chrome offset used when we set winopts ourselves (+8),
+      -- which covers borders, padding, and fzf's pointer indicator.
+      format_width = fzf_win_width - 8
+    else
+      format_width = math.floor(vim.o.columns * 0.8)
+    end
+  end
+
   local original_format_fn = opts.format_fn
   opts.format_fn = function(item)
-    return original_format_fn(item, opts.width)
+    return original_format_fn(item, format_width)
   end
 
   local title_str = type(opts.title) == 'function' and opts.title() or opts.title --[[@as string]]

--- a/lua/opencode/ui/base_picker.lua
+++ b/lua/opencode/ui/base_picker.lua
@@ -844,6 +844,17 @@ function M.pick(opts)
     opts.width = config.ui.picker_width
   end
 
+  -- picker_width = false means "use picker backend defaults, no override"
+  if opts.width == false then
+    opts.width = nil
+  end
+
+  -- Resolve relative width (0 < w <= 1) to absolute columns so that
+  -- format functions and all picker backends receive a consistent value.
+  if opts.width and opts.width > 0 and opts.width <= 1 then
+    opts.width = math.floor(vim.o.columns * opts.width)
+  end
+
   local original_format_fn = opts.format_fn
   opts.format_fn = function(item)
     return original_format_fn(item, opts.width)

--- a/lua/opencode/ui/history_picker.lua
+++ b/lua/opencode/ui/history_picker.lua
@@ -104,7 +104,7 @@ function M.pick(callback)
       end
     end,
     title = 'Select History Entry',
-    width = config.ui.picker_width or 100,
+    width = config.ui.picker_width,
     layout_opts = config.ui.picker,
   })
 end

--- a/lua/opencode/ui/reference_picker.lua
+++ b/lua/opencode/ui/reference_picker.lua
@@ -214,7 +214,7 @@ function M.pick()
       end
     end,
     title = 'Code References (' .. #refs .. ')',
-    width = config.ui.picker_width or 100,
+    width = config.ui.picker_width,
     preview = 'file',
     layout_opts = config.ui.picker,
   })

--- a/lua/opencode/ui/session_picker.lua
+++ b/lua/opencode/ui/session_picker.lua
@@ -332,7 +332,7 @@ function M.pick(sessions, callback)
     actions = actions,
     callback = callback,
     title = 'Select A Session',
-    width = config.ui.picker_width or 100,
+    width = config.ui.picker_width,
     layout_opts = config.ui.picker,
     preview = 'custom',
     ---@param session table

--- a/lua/opencode/ui/timeline_picker.lua
+++ b/lua/opencode/ui/timeline_picker.lua
@@ -41,7 +41,7 @@ function M.pick(messages, callback)
     actions = actions,
     callback = callback,
     title = 'Timeline',
-    width = config.ui.picker_width or 100,
+    width = config.ui.picker_width,
     layout_opts = config.ui.picker,
   })
 end


### PR DESCRIPTION
## Issue

`picker_width` only accepts absolute column counts. Users who want the picker to scale with their terminal size have no way to specify a relative width. Users who want to delegate sizing entirely to their picker backend (fzf-lua, telescope, snacks) cannot opt out of the hardcoded default since `vim.tbl_deep_extend` drops `nil` values during config merge.

Additionally, all four pickers hardcode an `or 100` fallback, preventing any opt-out value from propagating.

## Solution

Extend `picker_width` to support three modes:

- **Absolute** (`>1`): fixed column count, same as before (e.g. `picker_width = 120`)
- **Relative** (`0<w<=1`): fraction of screen width (e.g. `picker_width = 0.8` for 80%)
- **`false`**: delegate all sizing to the picker backend. Uses `false` instead of `nil` because `vim.tbl_deep_extend` cannot merge `nil` over a default value.

Non-breaking: the default `picker_width` remains `100` in @`config.lua`.

## Changes

- **Relative width resolution** (@`base_picker.lua`) — Resolve values in `(0, 1]` to absolute columns via `math.floor(vim.o.columns * w)` at the start of `M.pick()`, before format functions or backends consume the value.

- **`false` opt-out** (`base_picker.lua`) — Convert `false` to `nil` at the start of `M.pick()`. When `nil`, no @`winopts.width` override is passed to fzf-lua and format functions fall back to `vim.api.nvim_win_get_width(0)`.

- **Remove hardcoded fallbacks** (session, timeline, reference, history pickers) — Replace `config.ui.picker_width or 100` with `config.ui.picker_width` so `false` propagates cleanly through `M.pick()`.

- **Type annotation** (@`types.lua`) — Update `picker_width` field to document `number|false|nil` and the three modes.
