### PR TITLE
fix(picker): format fzf preview entries to list width

### DIFF
--- a/lua/opencode/ui/base_picker.lua
+++ b/lua/opencode/ui/base_picker.lua
@@ -515,17 +515,6 @@ local function fzf_ui(opts)
   local fzf_config = create_fzf_config()
   fzf_config.actions = actions_config
 
-  -- When a preview pane is active, fzf-lua splits the window (default
-  -- right:60% preview, left:40% list). Narrow opts.width so that the
-  -- format function produces entries sized for the list pane, not the
-  -- full window. The format closure reads opts.width on each call.
-  local has_preview = opts.preview and opts.preview ~= 'none' and opts.preview ~= false
-  if has_preview and opts.width then
-    local window_cols = opts.width + 8
-    -- list pane ≈ 40% of the window, minus a small border/padding allowance
-    opts.width = math.floor(window_cols * 0.4) - 4
-  end
-
   fzf_lua.fzf_exec(create_finder(), fzf_config)
 end
 
@@ -888,6 +877,14 @@ function M.pick(opts)
     else
       format_width = math.floor(vim.o.columns * 0.8)
     end
+  end
+
+  local has_preview = opts.preview and opts.preview ~= 'none' and opts.preview ~= false
+  if picker_type == 'fzf' and has_preview and format_width then
+    local window_cols = format_width + 8
+    -- Match fzf-lua's default right:60% preview split so item formatting
+    -- targets the visible list pane instead of the full window width.
+    format_width = math.floor(window_cols * 0.4) - 4
   end
 
   local original_format_fn = opts.format_fn

--- a/tests/unit/base_picker_spec.lua
+++ b/tests/unit/base_picker_spec.lua
@@ -233,6 +233,7 @@ end)
 
 describe('opencode.ui.base_picker fzf-lua preview', function()
   local base_picker
+  local captured_fzf_finder
   local captured_fzf_opts
   local original_schedule
   local saved_modules
@@ -290,10 +291,12 @@ describe('opencode.ui.base_picker fzf-lua preview', function()
       end,
     }
 
+    captured_fzf_finder = nil
     captured_fzf_opts = nil
 
     package.loaded['fzf-lua'] = {
-      fzf_exec = function(_, opts)
+      fzf_exec = function(finder, opts)
+        captured_fzf_finder = finder
         captured_fzf_opts = opts
       end,
     }
@@ -385,5 +388,33 @@ describe('opencode.ui.base_picker fzf-lua preview', function()
     assert.are.same({ 'fzf preview' }, lines)
 
     vim.api.nvim_buf_delete(next_preview_buf, { force = true })
+  end)
+
+  it('formats entries to the visible list width when preview is active', function()
+    local observed_width
+
+    base_picker.pick({
+      title = 'Test',
+      items = { { name = 'session' } },
+      format_fn = function(item, width)
+        observed_width = width
+        return base_picker.create_picker_item({ { text = item.name } })
+      end,
+      actions = {},
+      callback = function() end,
+      preview = 'custom',
+      preview_fn = function() end,
+    })
+
+    local emitted_lines = {}
+    captured_fzf_finder(function(line)
+      if line then
+        table.insert(emitted_lines, line)
+      end
+    end)
+
+    assert.equal(31, observed_width)
+    assert.are.same({ '1\001session' }, emitted_lines)
+    assert.equal(88, captured_fzf_opts.winopts.width)
   end)
 end)


### PR DESCRIPTION
## Issue

PR #399 fixed the fzf-lua session picker preview gutter, but the width handling for preview mode still used the full picker width for session rows. In practice, that pushed the datetime column off the visible list pane and truncated session rows down to the title and ellipsis.

## Solution

Make preview-aware width handling happen where picker item width is actually determined. The list width is now computed before the picker callback is wrapped, so fzf preview entries use the visible list pane width while the picker window itself still uses the full width.

## Changes

- Move the fzf preview width adjustment into `base_picker.pick()`, where item
  width is passed into the picker callback.
- Remove the ineffective @`opts.width` mutation from `fzf_ui()`, which happened
  too late to affect the rendered session rows.
- Add a regression test that verifies preview-mode entries use the list-pane
  width while fzf still receives the full window width.

