### PR TITLE
fix(renderer): scope shared-server events by session

### DIFF
--- a/lua/opencode/ui/event_scope.lua
+++ b/lua/opencode/ui/event_scope.lua
@@ -1,0 +1,134 @@
+local state = require('opencode.state')
+local session_scope = require('opencode.ui.session_scope')
+
+local M = {}
+
+local function active_session_id()
+  return state.active_session and state.active_session.id
+end
+
+---@param session_id string|nil
+---@return boolean
+local function active_session(session_id)
+  if not session_id or session_id == '' then
+    return false
+  end
+
+  return session_scope.belongs_to_active_session({ sessionID = session_id })
+end
+
+---@param properties table|nil
+---@return boolean
+local function active_session_update(properties)
+  local session = properties and properties.info
+  return session and session.id and session.id == active_session_id()
+end
+
+---@param properties table|nil
+---@return boolean
+local function active_message(properties)
+  local message = properties and properties.info
+  return active_session(message and message.sessionID)
+end
+
+---@param properties table|nil
+---@return boolean
+local function active_part(properties)
+  local part = properties and properties.part
+  if active_session(part and part.sessionID) then
+    return true
+  end
+
+  -- Task child events may arrive before their parent task part is indexed.
+  return part
+    and state.active_session
+    and part.sessionID
+    and part.sessionID ~= ''
+    and (part.tool ~= nil or part.type == 'tool')
+end
+
+---@param properties table|nil
+---@return boolean
+local function active_question_reply(properties)
+  if not properties or not properties.requestID then
+    return false
+  end
+
+  return require('opencode.ui.question_window').matches_active_question({
+    id = properties.requestID,
+  })
+end
+
+---@type table<string, fun(properties: table|nil): boolean>
+local policies = {
+  ['session.updated'] = active_session_update,
+  ['session.compacted'] = function(properties)
+    return active_session(properties and properties.sessionID)
+  end,
+  ['session.error'] = function(properties)
+    return active_session(properties and properties.sessionID)
+  end,
+  ['message.updated'] = active_message,
+  ['message.removed'] = function(properties)
+    return active_session(properties and properties.sessionID)
+  end,
+  ['message.part.updated'] = active_part,
+  ['message.part.removed'] = function(properties)
+    return active_session(properties and properties.sessionID)
+  end,
+  ['permission.updated'] = session_scope.belongs_to_active_session,
+  ['permission.asked'] = session_scope.belongs_to_active_session,
+  ['permission.replied'] = function(properties)
+    return active_session(properties and properties.sessionID)
+  end,
+  ['question.asked'] = session_scope.belongs_to_active_session,
+  ['question.replied'] = active_question_reply,
+  ['question.rejected'] = active_question_reply,
+  ['file.edited'] = function()
+    return true
+  end,
+  ['custom.restore_point.created'] = function()
+    return true
+  end,
+  ['custom.emit_events.finished'] = function()
+    return true
+  end,
+}
+
+---@param event_name string
+---@return boolean
+function M.has_policy(event_name)
+  return policies[event_name] ~= nil
+end
+
+---@param event_name string
+---@param properties table|nil
+---@return boolean
+function M.should_handle(event_name, properties)
+  local policy = policies[event_name]
+  if not policy then
+    return false
+  end
+
+  return policy(properties)
+end
+
+local wrappers = {}
+
+---@param event_name string
+---@param callback function
+---@return function
+function M.scoped_callback(event_name, callback)
+  wrappers[event_name] = wrappers[event_name] or setmetatable({}, { __mode = 'k' })
+  if not wrappers[event_name][callback] then
+    wrappers[event_name][callback] = function(properties)
+      if M.should_handle(event_name, properties) then
+        callback(properties)
+      end
+    end
+  end
+
+  return wrappers[event_name][callback]
+end
+
+return M

--- a/lua/opencode/ui/permission_window.lua
+++ b/lua/opencode/ui/permission_window.lua
@@ -1,5 +1,6 @@
 local state = require('opencode.state')
 local Dialog = require('opencode.ui.dialog')
+local session_scope = require('opencode.ui.session_scope')
 
 local M = {}
 
@@ -352,30 +353,10 @@ function M.restore_pending_permissions(session_id)
       end
 
       local events = require('opencode.ui.renderer.events')
-      local render_state = require('opencode.ui.renderer.ctx').render_state
 
       for _, permission in ipairs(permissions) do
         if permission and permission.id then
-          -- Check if this permission belongs to the active session or
-          -- one of its child sessions (task tool).
-          local belongs = permission.sessionID == session_id
-          if not belongs and permission.sessionID and permission.sessionID ~= '' then
-            belongs = render_state:get_task_part_by_child_session(permission.sessionID) ~= nil
-          end
-          if not belongs then
-            local tool = permission.tool
-            local tool_message_id = tool and tool.messageID
-            if tool_message_id and state.messages then
-              for _, message in ipairs(state.messages) do
-                if message.info and message.info.id == tool_message_id then
-                  belongs = true
-                  break
-                end
-              end
-            end
-          end
-
-          if belongs and not is_resolved_permission(permission) then
+          if session_scope.belongs_to_session(permission, session_id) and not is_resolved_permission(permission) then
             -- Check if already queued (avoid duplicate)
             local already_queued = false
             for _, existing in ipairs(M._permission_queue) do

--- a/lua/opencode/ui/question_window.lua
+++ b/lua/opencode/ui/question_window.lua
@@ -4,6 +4,7 @@ local Dialog = require('opencode.ui.dialog')
 local Promise = require('opencode.promise')
 
 local config = require('opencode.config')
+local session_scope = require('opencode.ui.session_scope')
 
 local M = {}
 
@@ -62,36 +63,6 @@ function M.matches_active_question(question_request)
     and M._current_question ~= nil
     and question_request.id ~= nil
     and M._current_question.id == question_request.id
-end
-
----@param question_request OpencodeQuestionRequest|nil
----@return boolean
-function M.belongs_to_active_session(question_request)
-  if not question_request then
-    return false
-  end
-
-  local active_session = state.active_session
-  if active_session and active_session.id and question_request.sessionID == active_session.id then
-    return true
-  end
-
-  local tool = question_request.tool
-  local tool_message_id = tool and tool.messageID
-  if tool_message_id and state.messages then
-    for _, message in ipairs(state.messages) do
-      if message.info and message.info.id == tool_message_id then
-        return true
-      end
-    end
-  end
-
-  if question_request.sessionID and question_request.sessionID ~= '' then
-    local render_state = require('opencode.ui.renderer.ctx').render_state
-    return render_state:get_task_part_by_child_session(question_request.sessionID) ~= nil
-  end
-
-  return false
 end
 
 ---@param question_request OpencodeQuestionRequest|nil
@@ -221,7 +192,7 @@ function M.restore_pending_question(session_id)
     return Promise.new():resolve(nil)
   end
 
-  if M.has_question() and M.belongs_to_active_session(M._current_question) then
+  if M.has_question() and session_scope.belongs_to_active_session(M._current_question) then
     if not is_resolved_question_request(M._current_question) then
       return Promise.new():resolve(nil)
     end
@@ -238,11 +209,11 @@ function M.restore_pending_question(session_id)
 
       for _, request in ipairs(requests) do
         if
-          request
-          and request.questions
-          and #request.questions > 0
-          and M.belongs_to_active_session(request)
-          and not is_resolved_question_request(request)
+            request
+            and request.questions
+            and #request.questions > 0
+            and session_scope.belongs_to_active_session(request)
+            and not is_resolved_question_request(request)
         then
           if M.matches_active_question(request) then
             return

--- a/lua/opencode/ui/renderer.lua
+++ b/lua/opencode/ui/renderer.lua
@@ -5,6 +5,7 @@ local permission_window = require('opencode.ui.permission_window')
 local Promise = require('opencode.promise')
 local ctx = require('opencode.ui.renderer.ctx')
 local events = require('opencode.ui.renderer.events')
+local event_scope = require('opencode.ui.event_scope')
 local flush = require('opencode.ui.renderer.flush')
 local scroll = require('opencode.ui.renderer.scroll')
 
@@ -259,6 +260,27 @@ end
 -- can be stubbed cleanly (e.g. stub(renderer, '_render_full_session_data'))
 M.on_session_updated = events.on_session_updated
 
+function M.event_subscriptions()
+  return {
+    { 'session.updated', events.on_session_updated },
+    { 'session.compacted', events.on_session_compacted },
+    { 'session.error', events.on_session_error },
+    { 'message.updated', events.on_message_updated },
+    { 'message.removed', events.on_message_removed },
+    { 'message.part.updated', events.on_part_updated },
+    { 'message.part.removed', events.on_part_removed },
+    { 'permission.updated', events.on_permission_updated },
+    { 'permission.asked', events.on_permission_updated },
+    { 'permission.replied', events.on_permission_replied },
+    { 'question.asked', events.on_question_asked },
+    { 'question.replied', events.on_question_replied },
+    { 'question.rejected', events.on_question_replied },
+    { 'file.edited', events.on_file_edited },
+    { 'custom.restore_point.created', events.on_restore_points },
+    { 'custom.emit_events.finished', M.on_emit_events_finished },
+  }
+end
+
 ---Reset all renderer state and clear the output buffer
 function M.reset()
   ctx:reset()
@@ -291,30 +313,12 @@ function M.setup_subscriptions(subscribe)
     return
   end
 
-  local subs = {
-    { 'session.updated', events.on_session_updated },
-    { 'session.compacted', events.on_session_compacted },
-    { 'session.error', events.on_session_error },
-    { 'message.updated', events.on_message_updated },
-    { 'message.removed', events.on_message_removed },
-    { 'message.part.updated', events.on_part_updated },
-    { 'message.part.removed', events.on_part_removed },
-    { 'permission.updated', events.on_permission_updated },
-    { 'permission.asked', events.on_permission_updated },
-    { 'permission.replied', events.on_permission_replied },
-    { 'question.asked', events.on_question_asked },
-    { 'question.replied', events.clear_question_display },
-    { 'question.rejected', events.clear_question_display },
-    { 'file.edited', events.on_file_edited },
-    { 'custom.restore_point.created', events.on_restore_points },
-    { 'custom.emit_events.finished', M.on_emit_events_finished },
-  }
-
-  for _, sub in ipairs(subs) do
+  for _, sub in ipairs(M.event_subscriptions()) do
+    local callback = event_scope.scoped_callback(sub[1], sub[2])
     if subscribe then
-      state.event_manager:subscribe(sub[1], sub[2])
+      state.event_manager:subscribe(sub[1], callback)
     else
-      state.event_manager:unsubscribe(sub[1], sub[2])
+      state.event_manager:unsubscribe(sub[1], callback)
     end
   end
 end

--- a/lua/opencode/ui/renderer/events.lua
+++ b/lua/opencode/ui/renderer/events.lua
@@ -504,10 +504,6 @@ function M.on_permission_updated(permission)
     return
   end
 
-  local tool = permission.tool
-  local callID = tool and tool.callID or permission.callID
-  local messageID = tool and tool.messageID or permission.messageID
-
   if not state.pending_permissions then
     state.renderer.set_pending_permissions({})
   end
@@ -561,7 +557,12 @@ function M.on_question_asked(properties)
   if not properties or not properties.id or not properties.questions then
     return
   end
-  require('opencode.ui.question_window').show_question(properties)
+  local question_window = require('opencode.ui.question_window')
+  question_window.show_question(properties)
+end
+
+function M.on_question_replied()
+  M.clear_question_display()
 end
 
 ---Handle file.edited — reload buffers and fire the hook

--- a/lua/opencode/ui/session_scope.lua
+++ b/lua/opencode/ui/session_scope.lua
@@ -1,0 +1,54 @@
+local state = require('opencode.state')
+
+local M = {}
+
+---@param request table|nil
+---@return string|nil
+local function get_message_id(request)
+  if not request then
+    return nil
+  end
+
+  local tool = request.tool
+  return (tool and tool.messageID) or request.messageID
+end
+
+---@param request table|nil
+---@param session_id string|nil
+---@return boolean
+function M.belongs_to_session(request, session_id)
+  if not request then
+    return false
+  end
+
+  if request.sessionID and request.sessionID ~= '' then
+    if request.sessionID == session_id then
+      return true
+    end
+
+    local render_state = require('opencode.ui.renderer.ctx').render_state
+    if render_state:get_task_part_by_child_session(request.sessionID) ~= nil then
+      return true
+    end
+  end
+
+  local message_id = get_message_id(request)
+  if message_id and state.messages then
+    for _, message in ipairs(state.messages) do
+      if message.info and message.info.id == message_id then
+        return true
+      end
+    end
+  end
+
+  return (not request.sessionID or request.sessionID == '') and session_id ~= nil and session_id ~= ''
+end
+
+---@param request table|nil
+---@return boolean
+function M.belongs_to_active_session(request)
+  local active_session = state.active_session
+  return M.belongs_to_session(request, active_session and active_session.id)
+end
+
+return M

--- a/tests/replay/renderer_spec.lua
+++ b/tests/replay/renderer_spec.lua
@@ -93,22 +93,13 @@ local function assert_output_matches(expected, actual, name)
 end
 
 describe('renderer unit tests', function()
-  local event_subscriptions = {
-    'session.updated',
-    'session.compacted',
-    'session.error',
-    'message.updated',
-    'message.removed',
-    'message.part.updated',
-    'message.part.removed',
-    'permission.updated',
-    'permission.replied',
-    'question.replied',
-    'question.asked',
-    'file.edited',
-    'custom.restore_point.created',
-    'custom.emit_events.finished',
-  }
+  local function event_subscriptions()
+    local names = {}
+    for _, sub in ipairs(require('opencode.ui.renderer').event_subscriptions()) do
+      table.insert(names, sub[1])
+    end
+    return names
+  end
 
   before_each(function()
     require('opencode.event_manager').setup()
@@ -122,7 +113,7 @@ describe('renderer unit tests', function()
 
     renderer.setup_subscriptions()
 
-    for _, event_name in ipairs(event_subscriptions) do
+    for _, event_name in ipairs(event_subscriptions()) do
       assert.is_true(
         event_manager.events[event_name] ~= nil,
         string.format('Renderer did not subscribe to event: %s', event_name)
@@ -138,7 +129,7 @@ describe('renderer unit tests', function()
 
     renderer.setup_subscriptions(false)
 
-    for _, event_name in ipairs(event_subscriptions) do
+    for _, event_name in ipairs(event_subscriptions()) do
       assert.is_true(
         vim.tbl_isempty(event_manager.events[event_name]),
         string.format('Renderer did not unsubscribe from event: %s', event_name)

--- a/tests/unit/event_scope_spec.lua
+++ b/tests/unit/event_scope_spec.lua
@@ -1,0 +1,75 @@
+local event_scope = require('opencode.ui.event_scope')
+local state = require('opencode.state')
+
+describe('event_scope', function()
+  before_each(function()
+    state.session.set_active({ id = 'session_active' })
+  end)
+
+  after_each(function()
+    state.session.set_active(nil)
+  end)
+
+  it('has a scope policy for every renderer event subscription', function()
+    for _, sub in ipairs(require('opencode.ui.renderer').event_subscriptions()) do
+      assert.is_true(event_scope.has_policy(sub[1]), 'Missing event scope policy for ' .. sub[1])
+    end
+  end)
+
+  it('rejects events without an explicit policy', function()
+    assert.is_false(event_scope.should_handle('unknown.event', {}))
+  end)
+
+  it('accepts active session events', function()
+    assert.is_true(event_scope.should_handle('session.compacted', {
+      sessionID = 'session_active',
+    }))
+  end)
+
+  it('rejects unrelated session events', function()
+    assert.is_false(event_scope.should_handle('session.compacted', {
+      sessionID = 'session_other',
+    }))
+  end)
+
+  it('rejects malformed session-scoped events', function()
+    assert.is_false(event_scope.should_handle('session.compacted', {}))
+  end)
+
+  it('rejects message parts from unrelated sessions', function()
+    assert.is_false(event_scope.should_handle('message.part.updated', {
+      part = {
+        id = 'part_other',
+        messageID = 'message_other',
+        sessionID = 'session_other',
+        type = 'text',
+      },
+    }))
+  end)
+
+  it('accepts child-session tool parts before the parent task part is indexed', function()
+    assert.is_true(event_scope.should_handle('message.part.updated', {
+      part = {
+        id = 'part_child_tool',
+        messageID = 'message_child',
+        sessionID = 'session_child',
+        type = 'tool',
+      },
+    }))
+  end)
+
+  it('keeps legacy interactive ask events visible', function()
+    assert.is_true(event_scope.should_handle('permission.asked', {
+      id = 'permission_legacy',
+    }))
+  end)
+
+  it('returns a stable wrapper for the same event and callback', function()
+    local callback = function() end
+
+    assert.are.equal(
+      event_scope.scoped_callback('session.updated', callback),
+      event_scope.scoped_callback('session.updated', callback)
+    )
+  end)
+end)

--- a/tests/unit/permission_integration_spec.lua
+++ b/tests/unit/permission_integration_spec.lua
@@ -540,3 +540,82 @@ describe('permission prompt rendering', function()
     assert.equals(before[2], after[2])
   end)
 end)
+
+describe('cross-session realtime permission and question events', function()
+  local event_scope = require('opencode.ui.event_scope')
+  local question_window = require('opencode.ui.question_window')
+
+  before_each(function()
+    state.renderer.set_messages({})
+    state.renderer.set_pending_permissions({})
+    state.session.set_active({ id = 'session_123' })
+
+    permission_window._permission_queue = {}
+    permission_window._dialog = nil
+    permission_window._processing = false
+
+    question_window._current_question = nil
+    question_window._current_question_index = 1
+    question_window._collected_answers = {}
+    question_window._answering = false
+    question_window._dialog = nil
+
+    ctx.render_state:reset()
+    ctx.prev_line_count = 0
+  end)
+
+  it('ignores realtime permissions from another session', function()
+    event_scope.scoped_callback('permission.asked', events.on_permission_updated)({
+      id = 'perm_other_session',
+      sessionID = 'session_other',
+      permission = 'bash',
+      patterns = { 'echo other' },
+      metadata = {},
+    })
+
+    assert.are.equal(0, #state.pending_permissions)
+    assert.are.equal(0, permission_window.get_permission_count())
+  end)
+
+  it('ignores realtime questions from another session', function()
+    event_scope.scoped_callback('question.asked', events.on_question_asked)({
+      id = 'question_other_session',
+      sessionID = 'session_other',
+      questions = {
+        {
+          question = 'Pick one',
+          options = {
+            { label = 'One' },
+          },
+        },
+      },
+    })
+
+    assert.is_nil(question_window._current_question)
+  end)
+
+  it('does not clear the current question when another session replies', function()
+    question_window._current_question = {
+      id = 'question_current',
+      sessionID = 'session_123',
+      questions = {
+        {
+          question = 'Pick one',
+          options = {
+            { label = 'One' },
+          },
+        },
+      },
+    }
+
+    event_scope.scoped_callback('question.replied', events.on_question_replied)({
+      sessionID = 'session_other',
+      requestID = 'question_other',
+      answers = {
+        { 'One' },
+      },
+    })
+
+    assert.are.equal('question_current', question_window._current_question.id)
+  end)
+end)

--- a/tests/unit/session_scope_spec.lua
+++ b/tests/unit/session_scope_spec.lua
@@ -1,0 +1,75 @@
+local session_scope = require('opencode.ui.session_scope')
+local state = require('opencode.state')
+local ctx = require('opencode.ui.renderer.ctx')
+
+describe('session_scope', function()
+  before_each(function()
+    state.session.set_active({ id = 'session_active' })
+    state.renderer.set_messages({})
+    ctx.render_state:reset()
+  end)
+
+  after_each(function()
+    state.session.set_active(nil)
+    state.renderer.set_messages({})
+    ctx.render_state:reset()
+  end)
+
+  it('matches requests from the active session', function()
+    assert.is_true(session_scope.belongs_to_active_session({
+      id = 'request_active',
+      sessionID = 'session_active',
+    }))
+  end)
+
+  it('matches requests whose tool message is in the current session', function()
+    state.renderer.set_messages({
+      {
+        info = {
+          id = 'message_current',
+          sessionID = 'session_active',
+        },
+        parts = {},
+      },
+    })
+
+    assert.is_true(session_scope.belongs_to_active_session({
+      id = 'request_with_message',
+      sessionID = 'session_other',
+      tool = {
+        messageID = 'message_current',
+      },
+    }))
+  end)
+
+  it('matches requests from rendered child task sessions', function()
+    ctx.render_state:set_part({
+      id = 'task_part',
+      messageID = 'message_task',
+      tool = 'task',
+      state = {
+        metadata = {
+          sessionId = 'session_child',
+        },
+      },
+    }, 1, 1)
+
+    assert.is_true(session_scope.belongs_to_active_session({
+      id = 'request_child',
+      sessionID = 'session_child',
+    }))
+  end)
+
+  it('rejects requests from unrelated sessions', function()
+    assert.is_false(session_scope.belongs_to_active_session({
+      id = 'request_other',
+      sessionID = 'session_other',
+    }))
+  end)
+
+  it('keeps legacy requests without a session id visible for the active session', function()
+    assert.is_true(session_scope.belongs_to_active_session({
+      id = 'request_legacy',
+    }))
+  end)
+end)


### PR DESCRIPTION
Route renderer event subscriptions through explicit scope policies so global server events do not leak interactive prompts across sessions.

Centralize request ownership checks in session_scope and reuse them from permission/question restore paths. Keep task child-session tool parts working when child events arrive before the parent task part is indexed.

Fixes #405