### PR TITLE
fix(picker): restore picker_width=false opt-out in session picker

### DIFF
--- a/lua/opencode/ui/session_picker.lua
+++ b/lua/opencode/ui/session_picker.lua
@@ -347,7 +347,7 @@ function M.pick(sessions, callback, opts)
     actions = actions,
     callback = callback,
     title = (opts and opts.scope == 'global') and 'Select A Session (all projects)' or 'Select A Session',
-    width = config.ui.picker_width or 100,
+    width = config.ui.picker_width,
     layout_opts = config.ui.picker,
     preview = 'custom',
     ---@param session table


### PR DESCRIPTION
### Issue

Setting `picker_width = false` to opt out of width overrides and let the picker backend use its own defaults no longer works for the session picker. Commit `b977136` (#403) introduced `config.ui.picker_width or 100` in @`session_picker.lua`, which silently converts `false` into `100` before `base_picker.pick()` ever sees it. The `false` → `nil` opt-out conversion in `M.pick()` (added in #400) is never reached.

### Solution

Remove the `or 100` fallback so `picker_width` is passed through as-is. `M.pick()` already handles all three cases: a number is used directly, `nil` falls back to `config.ui.picker_width`, and `false` is converted to `nil` to let the backend decide its own window size.
