### PR TITLE
fix(picker): avoid each item split into multiple entry

### DIFF
--- a/lua/opencode/ui/base_picker.lua
+++ b/lua/opencode/ui/base_picker.lua
@@ -381,6 +381,7 @@ local function fzf_ui(opts)
         ['--multi'] = has_multi_action and true or nil,
         ['--with-nth'] = '2..', -- hide the index prefix from display
         ['--delimiter'] = '\x01', -- use SOH as delimiter (invisible char)
+        ['--read0'] = true,
       },
       _headers = { 'actions' },
       previewer = (function()


### PR DESCRIPTION
read0 can be useful in this case: `echo -en "a\nb" | fzf --read0`

EDIT: this can fix some empty line in `/timeline` picker.