### PR TITLE
fix: close the timer to avoid memory leak

### DIFF
--- a/lua/opencode/util.lua
+++ b/lua/opencode/util.lua
@@ -352,10 +352,10 @@ function M.format_cost(c)
 end
 
 function M.debounce(func, delay)
-  local timer = nil
+  local timer ---@type uv.uv_timer_t?
   return function(...)
-    if timer then
-      timer:stop()
+    if timer and not timer:is_closing() then
+      timer:close()
     end
     local args = { ... }
     timer = vim.defer_fn(function()


### PR DESCRIPTION
I notice my nvim sometime memory leak, not sure if this related but better to `close` the timer if it won't be used again. `close` will `stop` internally.