### PR TITLE
fix(ui): keep permission dialog responsive between sequential prompts

### DIFF
--- a/lua/opencode/ui/permission_window.lua
+++ b/lua/opencode/ui/permission_window.lua
@@ -161,6 +161,8 @@ function M.remove_permission(permission_id)
   else
     M._setup_dialog() -- Setup dialog for next permission
   end
+
+  require('opencode.ui.renderer.events').render_permissions_display()
 end
 
 ---Get currently selected permission (always the first one now)
@@ -274,6 +276,10 @@ function M._setup_dialog()
   end
 
   local function on_select(index)
+    if M._processing then
+      return
+    end
+
     if not check_focused() then
       return
     end
@@ -284,23 +290,21 @@ function M._setup_dialog()
     end
 
     M._processing = true
-    require('opencode.ui.renderer.events').render_permissions_display()
-    M._clear_dialog()
 
     local api = require('opencode.api')
     local actions = { 'accept', 'deny', 'accept_all' }
     local action = actions[index]
 
-    vim.defer_fn(function()
+    vim.schedule(function()
       if action then
         local api_func = api['permission_' .. action]
         if api_func then
           api_func(permission)
         end
       end
-      M.remove_permission(permission.id)
       M._processing = false
-    end, 50)
+      M.remove_permission(permission.id)
+    end)
   end
 
   local function on_navigate()
@@ -346,7 +350,8 @@ function M.restore_pending_permissions(session_id)
     return Promise.new():resolve(nil)
   end
 
-  return state.api_client:list_permissions()
+  return state.api_client
+    :list_permissions()
     :and_then(function(permissions)
       if not permissions or type(permissions) ~= 'table' then
         return

--- a/lua/opencode/ui/renderer/events.lua
+++ b/lua/opencode/ui/renderer/events.lua
@@ -578,13 +578,6 @@ function M.on_permission_replied(properties)
 
   permission_window.remove_permission(permission_id)
   state.renderer.set_pending_permissions(vim.deepcopy(permission_window.get_all_permissions()))
-
-  if #state.pending_permissions == 0 then
-    flush.queue_part_removal('permission-display-part')
-    flush.queue_message_removal('permission-display-message')
-  else
-    M.render_permissions_display()
-  end
 end
 
 ---Handle question.asked — show the question picker UI


### PR DESCRIPTION
## Summary
Sequential permission prompts could leave the UI stale: after selecting a permission, the permission display could be refreshed while `_processing` was still `true`, causing the next queued permission to skip rendering until another keypress forced a refresh.

- Reorder `on_select`: clear `_processing` **before** `remove_permission` so the next render is not skipped.
- Swap the 50ms `vim.defer_fn` for `vim.schedule`, and add a reentrancy guard at the top of `on_select`.
- Move the post-removal render into `remove_permission` itself, and drop the now-redundant render branch in `on_permission_replied`.

## Test plan
- `./run_tests.sh -t tests/unit/permission_window_spec.lua` - 25/25 pass
- `./run_tests.sh -t tests/unit/permission_integration_spec.lua` - 15/15 pass
- Manually reproduced the stale UI on `6ab7d2f`; gone on this branch