### PR TITLE
fix: emit opencode_output FileType event when window created

### DIFF
--- a/lua/opencode/ui/output_window.lua
+++ b/lua/opencode/ui/output_window.lua
@@ -86,8 +86,6 @@ end
 ---@return integer
 function M.create_buf()
   local output_buf = vim.api.nvim_create_buf(false, true)
-  local filetype = config.ui.output.filetype or 'opencode_output'
-  vim.api.nvim_set_option_value('filetype', filetype, { buf = output_buf })
 
   vim.api.nvim_buf_set_var(output_buf, 'opencode_folds', build_fold_state({}))
 

--- a/lua/opencode/ui/ui.lua
+++ b/lua/opencode/ui/ui.lua
@@ -386,6 +386,12 @@ function M.create_windows()
 
   windows.input_win = win_ids.input_win
   windows.output_win = win_ids.output_win
+
+  local filetype = config.ui.output.filetype or 'opencode_output'
+  vim.api.nvim_win_call(windows.output_win, function()
+    vim.api.nvim_set_option_value('filetype', filetype, { buf = buffers.output_buf })
+  end)
+
   windows.saved_width_ratio = state.last_window_width_ratio
 
   input_window.setup(windows)

--- a/tests/unit/output_window_spec.lua
+++ b/tests/unit/output_window_spec.lua
@@ -17,26 +17,32 @@ local function parse_fillchars(value)
   return result
 end
 
-describe('output_window.create_buf', function()
+describe('ui.create_windows output filetype', function()
+  local ui = require('opencode.ui.ui')
   local original_config
+  local windows
 
   before_each(function()
     original_config = vim.deepcopy(config.values)
     config.values = vim.deepcopy(config.defaults)
+    state.ui.set_windows(nil)
   end)
 
   after_each(function()
+    if windows then
+      pcall(ui.close_windows, windows, false)
+      windows = nil
+    end
+    state.ui.set_windows(nil)
     config.values = original_config
   end)
 
   it('uses default output filetype', function()
     config.setup({})
-    local buf = output_window.create_buf()
+    windows = ui.create_windows()
 
-    local filetype = vim.api.nvim_get_option_value('filetype', { buf = buf })
+    local filetype = vim.api.nvim_get_option_value('filetype', { buf = windows.output_buf })
     assert.equals('opencode_output', filetype)
-
-    pcall(vim.api.nvim_buf_delete, buf, { force = true })
   end)
 
   it('uses configured output filetype', function()
@@ -48,12 +54,10 @@ describe('output_window.create_buf', function()
       },
     })
 
-    local buf = output_window.create_buf()
-    local filetype = vim.api.nvim_get_option_value('filetype', { buf = buf })
+    windows = ui.create_windows()
+    local filetype = vim.api.nvim_get_option_value('filetype', { buf = windows.output_buf })
 
     assert.equals('markdown', filetype)
-
-    pcall(vim.api.nvim_buf_delete, buf, { force = true })
   end)
 end)
 


### PR DESCRIPTION
make this possible in ftplugin/opencode_output.lua
```lua
vim.wo[0][0].conceallevel = 2
```
