### PR TITLE
feat(session-picker): add fork session action with keybinding

### DIFF
--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -113,6 +113,7 @@ M.defaults = {
       rename_session = { '<C-r>',                                              desc = 'Rename selected session' },
       delete_session = { '<C-d>',                                              desc = 'Delete selected sessions' },
       new_session =    { '<C-s>',                                              desc = 'Create a new session' },
+      fork_session =  { '<C-f>',                                              desc = 'Fork selected session' },
     },
     timeline_picker = {
       undo = { '<C-u>',                                   mode = { 'i', 'n' }, desc = 'Undo to selected message' },

--- a/lua/opencode/types.lua
+++ b/lua/opencode/types.lua
@@ -169,6 +169,7 @@
 ---@field delete_session OpencodeKeymapEntry
 ---@field new_session OpencodeKeymapEntry
 ---@field rename_session OpencodeKeymapEntry
+---@field fork_session OpencodeKeymapEntry
 
 ---@class OpencodeTimelinePickerKeymap
 ---@field undo OpencodeKeymapEntry

--- a/lua/opencode/ui/session_picker.lua
+++ b/lua/opencode/ui/session_picker.lua
@@ -336,6 +336,21 @@ function M.pick(sessions, callback, opts)
       end),
       reload = true,
     },
+    fork = {
+      key = config.keymap.session_picker.fork_session,
+      label = 'fork',
+      fn = Promise.async(function(selected, opts)
+        local state = require('opencode.state')
+        local session_runtime = require('opencode.services.session_runtime')
+        local new_session = state.api_client:fork_session(selected.id):await()
+        if new_session then
+          session_runtime.switch_session(new_session.id):await()
+          table.insert(opts.items, 1, new_session)
+          return opts.items
+        end
+      end),
+      reload = true,
+    },
   }
 
   -- Preview state for race condition protection


### PR DESCRIPTION
This should fix #425

Add <C-f> keymap to the session picker to fork

<img width="1534" height="180" alt="e7e53bc38d6c4c41eee8cd8c8122b550612418b01593979446611f4faee6a42a" src="https://github.com/user-attachments/assets/3cbdc8d2-8e8c-4d97-9811-c34c7709e0de" />
