### PR TITLE
fix(skills): load skills for using them as commands

### DIFF
--- a/lua/opencode/commands/slash.lua
+++ b/lua/opencode/commands/slash.lua
@@ -142,6 +142,30 @@ M.get_commands = Promise.async(function()
     end
   end
 
+  local state = require('opencode.state')
+  local ok, skills = pcall(function()
+    return state.api_client:list_skills():await()
+  end)
+  if ok and skills then
+    for _, skill in ipairs(skills) do
+      local skill_content = skill.content
+      table.insert(result, {
+        slash_cmd = '/' .. skill.name,
+        desc = skill.description or 'Skill',
+        fn = function(args)
+          local message = skill_content
+          if args and #args > 0 then
+            message = skill_content .. '\n\n' .. table.concat(args, ' ')
+          end
+          require('opencode.services.session_runtime').open({ new_session = false, focus = 'output' }):and_then(function()
+            return require('opencode.services.messaging').send_message(message, {})
+          end)
+        end,
+        args = true,
+      })
+    end
+  end
+
   return result
 end)
 


### PR DESCRIPTION
**Problem:**

Typing a skill name directly as a slash command (e.g. `/my-skill`) in the input window and pressing Enter produces `Unknown command: my-skill` and does nothing.

**Root Cause:**

Skills were only executable through the completion popup. The completion source (`completion/skills.lua`) handles the `on_complete` callback by directly calling `send_message(skill.content)` — but this path is bypassed when the user types the full command and submits without selecting a completion item.

`handle_submit` detects the `/` prefix and routes to `_execute_slash_command`, which resolves the command against the list returned by `slash.lua`'s `M.get_commands()`. That list only contained built-in slash commands and user config commands (`cfg.command`). Skills were never registered there, so lookup always failed.

**Solution:**

Extend `M.get_commands()` in `slash.lua` to also load available skills via `api_client:list_skills()` and register each one as a runtime slash command. The handler mirrors what the completion `on_complete` already does: open the session and send `skill.content` as a message. Skills are fetched with `pcall` so a failed API call degrades gracefully without breaking the rest of the command list.
