### PR TITLE
fix: slow `opencode --version` cause mismatch version

### DIFF
--- a/lua/opencode/api_client.lua
+++ b/lua/opencode/api_client.lua
@@ -518,7 +518,8 @@ function OpencodeApiClient:subscribe_to_events(directory, on_event)
     return nil
   end
 
-  if is_version_greater_or_equal(state.opencode_cli_version, '1.14.42') then
+  local version = assert(state.opencode_cli_version):wait()
+  if is_version_greater_or_equal(version, '1.14.42') then
     return self:_subscribe_to_global_events(directory, on_event)
   end
 
@@ -548,7 +549,8 @@ function OpencodeApiClient:_subscribe_to_global_events(directory, on_event)
     return nil
   end
 
-  if not is_version_greater_or_equal(state.opencode_cli_version, '1.14.42') then
+  local version = assert(state.opencode_cli_version):wait()
+  if not is_version_greater_or_equal(version, '1.14.42') then
     error('subscribe_to_global_events should not be called directly')
   end
 

--- a/lua/opencode/services/session_runtime.lua
+++ b/lua/opencode/services/session_runtime.lua
@@ -290,14 +290,17 @@ M.opencode_ok = Promise.async(function()
     return false
   end
 
-  if not state.opencode_cli_version or state.opencode_cli_version == '' then
-    local result = Promise.system({ config.opencode_executable, '--version' }):await()
-    local out = (result and result.stdout or ''):gsub('%s+$', '')
-    state.jobs.set_opencode_cli_version(out:match('(%d+%%.%d+%%.%d+)') or out)
+  if not state.opencode_cli_version then
+    local promise = Promise.system({ config.opencode_executable, '--version' }):and_then(function(result)
+      local out = (result and result.stdout or ''):gsub('%s+$', '')
+      out = out:match('(%d+%%.%d+%%.%d+)') or out
+      return Promise.new():resolve(out)
+    end) ---@type Promise<string>
+    state.jobs.set_opencode_cli_version(promise)
   end
 
   local required = state.required_version
-  local current_version = state.opencode_cli_version
+  local current_version = state.opencode_cli_version:await()
 
   if not current_version or current_version == '' then
     vim.notify(string.format('Unable to detect opencode CLI version. Requires >= %s', required), vim.log.levels.ERROR)

--- a/lua/opencode/state/jobs.lua
+++ b/lua/opencode/state/jobs.lua
@@ -53,7 +53,7 @@ function M.set_event_manager(manager)
   return store.set('event_manager', manager)
 end
 
----@param version string|nil
+---@param version Promise<string>|nil
 function M.set_opencode_cli_version(version)
   return store.set('opencode_cli_version', version)
 end

--- a/lua/opencode/state/store.lua
+++ b/lua/opencode/state/store.lua
@@ -39,7 +39,7 @@ local M = {}
 ---@field pre_zoom_width integer|nil
 ---@field last_window_width_ratio number|nil
 ---@field required_version string
----@field opencode_cli_version string|nil
+---@field opencode_cli_version Promise<string>|nil
 ---@field current_cwd string|nil
 ---@field session_locked boolean|nil
 ---@field _hidden_buffers OpencodeHiddenBuffers|nil

--- a/tests/unit/api_client_spec.lua
+++ b/tests/unit/api_client_spec.lua
@@ -120,7 +120,8 @@ describe('api_client', function()
   it('normalizes /global/event payloads into legacy event shape', function()
     local server_job = require('opencode.server_job')
     local original_stream_api = server_job.stream_api
-    state.jobs.set_opencode_cli_version('1.14.42')
+    local Promise = require('opencode.promise')
+    state.jobs.set_opencode_cli_version(Promise.new():resolve('1.14.42'))
 
     local received = {}
 
@@ -163,7 +164,8 @@ describe('api_client', function()
   it('normalizes /global/event sync payloads into legacy event shape', function()
     local server_job = require('opencode.server_job')
     local original_stream_api = server_job.stream_api
-    state.jobs.set_opencode_cli_version('1.14.42')
+    local Promise = require('opencode.promise')
+    state.jobs.set_opencode_cli_version(Promise.new():resolve('1.14.42'))
 
     local received = {}
 


### PR DESCRIPTION
This happened in background, version can be still nil when used.
```
$ time opencode --version
1.17.10

________________________________________________________
Executed in  403.82 millis    fish           external
   usr time  516.98 millis  522.00 micros  516.46 millis
   sys time   45.78 millis    0.00 micros   45.78 millis

```
