### PR TITLE
docs: update Docker spawn example

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,7 +834,7 @@ Use `spawn_command` to automatically start your server and `kill_command` to sto
 ```lua
 require('opencode').setup({
   server = {
-    url = 'localhost',
+    url = 'https://localhost',
     port = 'auto',  -- Random port for project isolation
     -- Path mapping: translate host paths to container paths
     path_map = function(host_path)
@@ -870,7 +870,7 @@ docker run -d --rm \
 -v ~/.local/share/opencode:/home/node/.local/share/opencode \
 -v ~/.config/opencode:/home/node/.config/opencode \
 -v "%s":/app:rw \
-opencode:latest opencode serve --port 4096 --hostname '0.0.0.0']],
+ghcr.io/anomalyco/opencode:latest serve --port 4096 --hostname '0.0.0.0']],
         container_name,
         port,
         cwd


### PR DESCRIPTION
## Summary
Fixes #343

Update the README Docker auto-spawn example so it works with the current opencode container image.

## Changes
- Use `https://localhost` for the local Docker server URL.
- Use the official `ghcr.io/anomalyco/opencode:latest` image.
- Pass `serve --port 4096 --hostname '0.0.0.0'` directly to the image instead of repeating the `opencode` command.

## Test Plan
- Verified README Markdown code fences are balanced.
- Checked the updated example contains the requested image/command and no longer contains the old `opencode:latest opencode serve` command.