### PR TITLE
fix: add_visual_selection_inline shouldn't trim indent

### DIFF
--- a/lua/opencode/context.lua
+++ b/lua/opencode/context.lua
@@ -196,7 +196,7 @@ function M.build_inline_selection_text(range)
 
   local fence = string.rep('`', n)
   local filetype = vim.bo[buf].filetype or ''
-  local code = current_selection.text:gsub('^%s+', ''):gsub('%s+$', '')
+  local code = current_selection.text:gsub('^%s+\r?\n', ''):gsub('%s+$', '')
   local text ---@type string
   if file then
     text = string.format('**`%s`**\n\n%s%s\n%s\n%s', file.path, fence, filetype, code, fence)

--- a/tests/unit/context_spec.lua
+++ b/tests/unit/context_spec.lua
@@ -1204,7 +1204,7 @@ describe('build_inline_selection_text', function()
       return false
     end
     BaseContext.get_current_selection = function()
-      return { text = 'function foo()\n  return 42\nend', lines = '10, 12' }
+      return { text = '  function foo()\n  return 42\nend', lines = '10, 12' }
     end
     BaseContext.get_current_file_for_selection = function()
       return nil
@@ -1225,7 +1225,7 @@ describe('build_inline_selection_text', function()
     assert.is_not_nil(text)
     assert.is_nil(text:match('%*%*`'))
     assert.is_not_nil(text:match('```lua'))
-    assert.is_not_nil(text:match('function foo%(%)'))
+    assert.is_not_nil(text:match('  function foo%(%)'))
     assert.is_not_nil(text:match('```$'))
 
     util.is_buf_a_file = original_is_buf_a_file


### PR DESCRIPTION
fixup af4e1a8151f4cccc1267d3b6d4caeda858787741

```
  line1
  line2
```
 will be without this commit
```
line1
  line2
```
