### PR TITLE
docs: remove plenary from install dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,10 +44,6 @@ jobs:
       - name: Add nvim to PATH
         run: echo "${{ steps.setup_nvim.outputs.executable }}" >> $GITHUB_PATH
 
-      - name: Install plenary
-        run: |
-          git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
-
       - name: Run tests
         run: ./run_tests.sh
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ Install the plugin with your favorite package manager. See the [Configuration](#
     require("opencode").setup({})
   end,
   dependencies = {
-    "nvim-lua/plenary.nvim",
     {
       "MeanderingProgrammer/render-markdown.nvim",
       opts = {


### PR DESCRIPTION
## Summary
- remove `nvim-lua/plenary.nvim` from the lazy.nvim installation example because the plugin runtime no longer requires it
- remove the redundant CI step that installed plenary globally; the test init still provisions the test harness under `deps/` when tests run

Closes #394 for the user-facing/runtime dependency path while keeping the current test harness unchanged.

## Validation
- `git diff --check`
- `rg -n "nvim-lua/plenary.nvim|Install plenary|plenary.nvim" README.md .github/workflows/tests.yml lua plugin ftplugin` (no matches)
- Could not run `./run_tests.sh -t minimal` locally because this machine does not have `nvim` installed; the command exits before tests with `nvim: command not found`.
