### PR TITLE
fix(autocmd): skip non-normal buftype for performance

### DIFF
--- a/lua/opencode/ui/autocmds.lua
+++ b/lua/opencode/ui/autocmds.lua
@@ -43,7 +43,7 @@ function M.setup_autocmds(windows)
     group = group,
     pattern = '*',
     callback = function(args)
-      if args.file == '' then
+      if args.file == '' or vim.bo[args.buf].buftype ~= '' then
         return
       end
       require('opencode.ui.renderer.events').invalidate_reference_targets_for_file_change()


### PR DESCRIPTION
I notice `:terminal` becuase obviously slow after eebda20e320100c481ab33b87571481dbab99371

Not sure why `M.invalidate_reference_targets_for_file_change()` is slow, but I think no problem to skip special buffer here.
