### PR TITLE
fix(autocmd): skip non-normal buftype for performance

### DIFF
--- a/lua/opencode/ui/autocmds.lua
+++ b/lua/opencode/ui/autocmds.lua
@@ -43,7 +43,7 @@ function M.setup_autocmds(windows)
     group = group,
     pattern = '*',
     callback = function(args)
-      if args.file == '' then
+      if args.file == '' or vim.bo[args.buf].buftype ~= '' then
         return
       end
       require('opencode.ui.renderer.events').invalidate_reference_targets_for_file_change()

--- a/tests/unit/hooks_spec.lua
+++ b/tests/unit/hooks_spec.lua
@@ -267,8 +267,10 @@ describe('reference target local file lifecycle autocmds', function()
         file_lifecycle_autocmd.event
       )
 
-      file_lifecycle_autocmd.opts.callback({ file = '/repo/tests/unit/formatter_spec.lua' })
-      file_lifecycle_autocmd.opts.callback({ file = '' })
+      local file_buf = vim.api.nvim_create_buf(false, false)
+      vim.bo[file_buf].buftype = ''
+      file_lifecycle_autocmd.opts.callback({ file = '/repo/tests/unit/formatter_spec.lua', buf = file_buf })
+      file_lifecycle_autocmd.opts.callback({ file = '', buf = file_buf })
 
       assert.stub(invalidate_stub).was_called(1)
     end)


### PR DESCRIPTION
I notice :terminal becuase obviously slow after eebda20

Not sure why M.invalidate_reference_targets_for_file_change() is slow, but I think no problem to skip special buffer here.

<img width="3434" height="874" alt="image" src="https://github.com/user-attachments/assets/dbcbbfe3-2a93-491e-ac93-4ea2777e0e91" />
before/after `:terminal`