### PR TITLE
feat(models-picker): use vim.ui.select as models picker

### DIFF
--- a/lua/opencode/commands/handlers/workflow.lua
+++ b/lua/opencode/commands/handlers/workflow.lua
@@ -223,6 +223,9 @@ function M.actions.mention_file()
   local context = require('opencode.context')
   require('opencode.ui.mention').mention(function(mention_cb)
     picker.pick(function(file)
+      if not file then
+        return
+      end
       mention_cb(file.path)
       context.add_file(file.path)
     end)

--- a/lua/opencode/ui/base_picker.lua
+++ b/lua/opencode/ui/base_picker.lua
@@ -760,6 +760,17 @@ local function snacks_picker_ui(opts)
   Snacks.picker.pick(snack_opts)
 end
 
+---vim.ui.select UI implementation
+---@param opts PickerOptions The picker options
+local function select_picker_ui(opts)
+  vim.ui.select(opts.items, {
+    format_item = function(item)
+      return opts.format_fn(item, opts.width):to_string()
+    end,
+    prompt = opts.title --[[@as string]]
+  }, opts.callback)
+end
+
 ---@param text? string
 ---@param width integer
 ---@param opts? {align?: "left" | "right" | "center", truncate?: boolean}
@@ -856,10 +867,6 @@ end
 function M.pick(opts)
   local picker_type = picker.get_best_picker()
 
-  if not picker_type then
-    return false
-  end
-
   if not opts.width then
     opts.width = config.ui.picker_width
   end
@@ -927,6 +934,9 @@ function M.pick(opts)
     elseif picker_type == 'snacks' then
       opts.title = build_title(title_str, opts.actions)
       snacks_picker_ui(opts)
+    elseif picker_type == 'select' then
+      opts.title = title_str
+      select_picker_ui(opts)
     else
       opts.callback(nil)
     end

--- a/lua/opencode/ui/file_picker.lua
+++ b/lua/opencode/ui/file_picker.lua
@@ -146,10 +146,6 @@ end
 function M.pick(callback, path)
   local picker_type = picker.get_best_picker()
 
-  if not picker_type then
-    return
-  end
-
   local wrapped_callback = function(selected_file)
     local file_name = format_file(selected_file)
     callback(file_name)

--- a/lua/opencode/ui/picker.lua
+++ b/lua/opencode/ui/picker.lua
@@ -7,10 +7,6 @@ local picker_aliases = {
 }
 
 local function normalize_picker_name(name)
-  if name == 'select' then
-    return nil
-  end
-
   return picker_aliases[name] or name
 end
 

--- a/tests/unit/picker_spec.lua
+++ b/tests/unit/picker_spec.lua
@@ -41,6 +41,6 @@ describe('opencode.ui.picker', function()
   end)
 
   it('keeps select as the explicit vim.ui.select fallback', function()
-    assert.is_nil(get_best_picker('select'))
+    assert.equal('select', get_best_picker('select'))
   end)
 end)


### PR DESCRIPTION
Attempt to fix #459 

This PR contain change in the base_picker to use vim.ui.select.

The vim.ui.select call is generic and the implementation detail of the custom vim.ui.select is left to the users.