### PR TITLE
feat: Support auth on remotes + Set password on local

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ require('opencode').setup({
     spawn_command = nil,   -- Optional function to start the server: function(port, url) ... end
     auto_kill = true,      -- Kill spawned servers when last nvim instance exits (default: true) Only applies to servers spawned by the plugin with spawn_command/kill_command
     path_map = nil,        -- Map host paths to server paths: string ('/app') or function(path) -> string
+    username = nil,        -- Username for Basic auth. Falls back to OPENCODE_SERVER_USERNAME env var, then "opencode"
+    password = nil,        -- Password for Basic auth. Falls back to OPENCODE_SERVER_PASSWORD env var
   },
 
   keymap = {
@@ -824,6 +826,48 @@ require('opencode').setup({
     port = 8080,
     timeout = 5,
   },
+})
+```
+
+### Authentication
+
+If your opencode server requires authentication, or if you would like the server that `opencode.nvim` starts to be behind authentication, you have a few options on how to provide the username and password.
+
+If Neovim has the `OPENCODE_SERVER_PASSWORD` environment variable set the plugin will automatically use them for authentication. The username is optional (will default to `opencode`), but can also be set with `OPENCODE_SERVER_USERNAME`.
+
+You can also supply the username and password directly in the config:
+
+```lua
+require('opencode').setup({
+  server = {
+    url = 'localhost',
+    port = 8080,
+    username = 'your_username_here', -- Optional, defaults to 'opencode' if not provided.
+    password = 'your_password_here',
+  }
+})
+```
+
+Both the `username` and `password` fields accept a `function` that returns a string. The results will be cached for the session, and are only called when first attempting to start or connect to a server:
+
+```lua
+require('opencode').setup({
+  server = {
+    url = 'localhost',
+    port = 8080,
+    username = function()
+      local keyfile = vim.fn.expand('~/.config/opencode/server-username')
+      if vim.fn.filereadable(keyfile) == 1 then
+        return vim.fn.trim(vim.fn.readfile(keyfile)[1])
+      end
+    end,
+    password = function()
+      local keyfile = vim.fn.expand('~/.config/opencode/server-password')
+      if vim.fn.filereadable(keyfile) == 1 then
+        return vim.fn.trim(vim.fn.readfile(keyfile)[1])
+      end
+    end,
+  }
 })
 ```
 

--- a/lua/opencode/auth.lua
+++ b/lua/opencode/auth.lua
@@ -2,6 +2,7 @@ local config = require('opencode.config')
 
 local M = {}
 
+---@type {password: string | nil, username: string} | nil
 local cache = nil
 
 --- Resolve a credential value that may be a string or a function returning a string.
@@ -26,20 +27,15 @@ end
 ---@return string|nil password
 ---@return string username
 local function ensure_resolved()
-  if cache then
-    return cache.password, cache.username
+  if cache == nil then
+    local password = resolve_credential(config.server.password) or vim.env.OPENCODE_SERVER_PASSWORD
+    local username = resolve_credential(config.server.username) or vim.env.OPENCODE_SERVER_USERNAME or 'opencode'
+
+    cache = {
+      password = password,
+      username = username,
+    }
   end
-
-  local password = resolve_credential(config.server.password)
-    or vim.env.OPENCODE_SERVER_PASSWORD
-  local username = resolve_credential(config.server.username)
-    or vim.env.OPENCODE_SERVER_USERNAME
-    or 'opencode'
-
-  cache = {
-    password = password,
-    username = username,
-  }
 
   return cache.password, cache.username
 end

--- a/lua/opencode/auth.lua
+++ b/lua/opencode/auth.lua
@@ -1,0 +1,63 @@
+local config = require('opencode.config')
+
+local M = {}
+
+local cache = nil
+
+--- Resolve a credential value that may be a string or a function returning a string.
+--- Returns nil for nil, empty string, or function errors.
+---@param val string | (fun(): string | nil) | nil
+---@return string | nil
+local function resolve_credential(val)
+  if type(val) == 'function' then
+    local ok, result = pcall(val)
+    if ok and result and result ~= '' then
+      return result
+    end
+    return nil
+  end
+  if val and val ~= '' then
+    return val
+  end
+  return nil
+end
+
+--- Resolve and cache credentials from config + env vars.
+---@return string|nil password
+---@return string username
+local function ensure_resolved()
+  if cache then
+    return cache.password, cache.username
+  end
+
+  local password = resolve_credential(config.server.password)
+    or vim.env.OPENCODE_SERVER_PASSWORD
+  local username = resolve_credential(config.server.username)
+    or vim.env.OPENCODE_SERVER_USERNAME
+    or 'opencode'
+
+  cache = {
+    password = password,
+    username = username,
+  }
+
+  return cache.password, cache.username
+end
+
+--- Reset cached credentials. Call after changing config values.
+function M.clear_cache()
+  cache = nil
+end
+
+--- Resolve credentials and return Authorization headers for HTTP Basic Auth.
+--- Returns an empty table if no password is configured (server doesn't require auth).
+---@return table<string, string> headers
+function M.get_auth_headers()
+  local password, username = ensure_resolved()
+  if not password then
+    return {}
+  end
+
+  local encoded = vim.base64.encode(username .. ':' .. password)
+  return { ['Authorization'] = 'Basic ' .. encoded }
+end

--- a/lua/opencode/auth.lua
+++ b/lua/opencode/auth.lua
@@ -61,3 +61,20 @@ function M.get_auth_headers()
   local encoded = vim.base64.encode(username .. ':' .. password)
   return { ['Authorization'] = 'Basic ' .. encoded }
 end
+
+--- Resolve credentials and return environment variables for a spawned server.
+--- Returns an empty table if no password is configured.
+---@return table<string, string> env
+function M.get_env()
+  local password, username = ensure_resolved()
+  if not password then
+    return {}
+  end
+
+  return {
+    OPENCODE_SERVER_PASSWORD = password,
+    OPENCODE_SERVER_USERNAME = username,
+  }
+end
+
+return M

--- a/lua/opencode/auth.lua
+++ b/lua/opencode/auth.lua
@@ -17,9 +17,11 @@ local function resolve_credential(val)
     end
     return nil
   end
+
   if val and val ~= '' then
     return val
   end
+
   return nil
 end
 

--- a/lua/opencode/config.lua
+++ b/lua/opencode/config.lua
@@ -24,6 +24,8 @@ M.defaults = {
     auto_kill = true,
     path_map = nil,
     reverse_path_map = nil,
+    username = nil,
+    password = nil,
   },
   -- stylua: ignore
   keymap = {

--- a/lua/opencode/opencode_server.lua
+++ b/lua/opencode/opencode_server.lua
@@ -3,6 +3,7 @@ local safe_call = util.safe_call
 local Promise = require('opencode.promise')
 local config = require('opencode.config')
 local curl = require('opencode.curl')
+local auth = require('opencode.auth')
 
 --- @class OpencodeServer
 --- @field job any The vim.system job handle
@@ -95,6 +96,7 @@ function OpencodeServer.health_check(url, timeout_ms)
   curl.request({
     url = url,
     method = 'GET',
+    headers = auth.get_auth_headers(),
     timeout = timeout_ms or 2000,
     proxy = '',
     callback = function(response)
@@ -176,6 +178,7 @@ function OpencodeServer.request_graceful_shutdown(base_url)
     curl.request({
       url = shutdown_url,
       method = 'POST',
+      headers = auth.get_auth_headers(),
       timeout = 1000,
       proxy = '',
       callback = function(response)

--- a/lua/opencode/opencode_server.lua
+++ b/lua/opencode/opencode_server.lua
@@ -275,6 +275,7 @@ function OpencodeServer:spawn(opts)
   self.mode = 'serve'
   self.job = vim.system(cmd, {
     cwd = opts.cwd,
+    env = auth.get_env(),
     stdout = function(err, data)
       if err then
         fail_startup(err)

--- a/lua/opencode/server_job.lua
+++ b/lua/opencode/server_job.lua
@@ -6,6 +6,7 @@ local port_mapping = require('opencode.port_mapping')
 local log = require('opencode.log')
 local config = require('opencode.config')
 local util = require('opencode.util')
+local auth = require('opencode.auth')
 
 local M = {}
 M.requests = {}
@@ -75,7 +76,7 @@ function M.call_api(url, method, body)
   local opts = {
     url = url,
     method = method or 'GET',
-    headers = { ['Content-Type'] = 'application/json' },
+    headers = vim.tbl_extend('force', { ['Content-Type'] = 'application/json' }, auth.get_auth_headers()),
     proxy = '',
     callback = function(response)
       remove_from_requests()
@@ -128,6 +129,7 @@ function M.stream_api(url, method, body, on_chunk)
   local opts = {
     url = url,
     method = method or 'GET',
+    headers = auth.get_auth_headers(),
     proxy = '',
     stream = function(err, chunk)
       on_chunk(chunk)

--- a/lua/opencode/types.lua
+++ b/lua/opencode/types.lua
@@ -206,6 +206,8 @@
 ---@field auto_kill boolean -- Kill spawned servers when nvim exits (default: true)
 ---@field path_map (string | fun(host_path: string): string) | nil -- Map host paths to server paths
 ---@field reverse_path_map (fun(server_path: string): string) | nil -- Map server paths back to host paths
+---@field username? string | fun(): string | nil -- Username for Basic auth. Falls back to OPENCODE_SERVER_USERNAME env var, then "opencode"
+---@field password? string | fun(): string | nil -- Password for Basic auth. Falls back to OPENCODE_SERVER_PASSWORD env var
 
 ---@class OpencodeUIFloatConfig
 ---@field width number # Width in columns, or ratio when <= 1 (default: 0.95)

--- a/tests/unit/auth_spec.lua
+++ b/tests/unit/auth_spec.lua
@@ -1,0 +1,252 @@
+local auth = require('opencode.auth')
+local config = require('opencode.config')
+
+describe('auth', function()
+  local original_config
+  local original_env_password
+  local original_env_username
+
+  before_each(function()
+    auth.clear_cache()
+    original_config = vim.deepcopy(config.values)
+    original_env_password = vim.env.OPENCODE_SERVER_PASSWORD
+    original_env_username = vim.env.OPENCODE_SERVER_USERNAME
+    config.values.server.password = nil
+    config.values.server.username = nil
+    vim.env.OPENCODE_SERVER_PASSWORD = nil
+    vim.env.OPENCODE_SERVER_USERNAME = nil
+  end)
+
+  after_each(function()
+    config.values = original_config
+    if original_env_password then
+      vim.env.OPENCODE_SERVER_PASSWORD = original_env_password
+    else
+      vim.env.OPENCODE_SERVER_PASSWORD = nil
+    end
+    if original_env_username then
+      vim.env.OPENCODE_SERVER_USERNAME = original_env_username
+    else
+      vim.env.OPENCODE_SERVER_USERNAME = nil
+    end
+  end)
+
+  it('returns empty table when no password is configured', function()
+    local headers = auth.get_auth_headers()
+    assert.same({}, headers)
+  end)
+
+  it('returns empty table when password is empty string', function()
+    config.values.server.password = ''
+    local headers = auth.get_auth_headers()
+    assert.same({}, headers)
+  end)
+
+  it('returns Basic auth header when password is in config', function()
+    config.values.server.password = 'secret'
+    local headers = auth.get_auth_headers()
+    assert.equals('Basic ' .. vim.base64.encode('opencode:secret'), headers['Authorization'])
+  end)
+
+  it('uses configured username from config', function()
+    config.values.server.username = 'admin'
+    config.values.server.password = 'password123'
+    local headers = auth.get_auth_headers()
+    assert.equals('Basic ' .. vim.base64.encode('admin:password123'), headers['Authorization'])
+  end)
+
+  it('defaults username to "opencode" when not configured', function()
+    config.values.server.password = 'secret'
+    local headers = auth.get_auth_headers()
+    assert.equals('Basic ' .. vim.base64.encode('opencode:secret'), headers['Authorization'])
+  end)
+
+  it('falls back to OPENCODE_SERVER_PASSWORD env var', function()
+    vim.env.OPENCODE_SERVER_PASSWORD = 'envpass'
+    local headers = auth.get_auth_headers()
+    assert.equals('Basic ' .. vim.base64.encode('opencode:envpass'), headers['Authorization'])
+  end)
+
+  it('falls back to OPENCODE_SERVER_USERNAME env var', function()
+    config.values.server.password = 'secret'
+    vim.env.OPENCODE_SERVER_USERNAME = 'envuser'
+    local headers = auth.get_auth_headers()
+    local decoded = vim.base64.decode(headers['Authorization']:match('Basic (.+)'))
+    assert.equals('envuser:secret', decoded)
+  end)
+
+  it('config values take precedence over env vars', function()
+    config.values.server.username = 'cfguser'
+    config.values.server.password = 'cfgpass'
+    vim.env.OPENCODE_SERVER_USERNAME = 'envuser'
+    vim.env.OPENCODE_SERVER_PASSWORD = 'envpass'
+    local headers = auth.get_auth_headers()
+    local decoded = vim.base64.decode(headers['Authorization']:match('Basic (.+)'))
+    assert.equals('cfguser:cfgpass', decoded)
+  end)
+
+  it('defaults username to "opencode" when only env password is set', function()
+    vim.env.OPENCODE_SERVER_PASSWORD = 'envpass'
+    local headers = auth.get_auth_headers()
+    local decoded = vim.base64.decode(headers['Authorization']:match('Basic (.+)'))
+    assert.equals('opencode:envpass', decoded)
+  end)
+
+  describe('function values', function()
+    it('resolves password from a function', function()
+      config.values.server.password = function()
+        return 'funcpass'
+      end
+      local headers = auth.get_auth_headers()
+      assert.equals('Basic ' .. vim.base64.encode('opencode:funcpass'), headers['Authorization'])
+    end)
+
+    it('resolves username from a function', function()
+      config.values.server.password = 'secret'
+      config.values.server.username = function()
+        return 'funcuser'
+      end
+      local headers = auth.get_auth_headers()
+      assert.equals('Basic ' .. vim.base64.encode('funcuser:secret'), headers['Authorization'])
+    end)
+
+    it('function returning nil falls through to env var', function()
+      config.values.server.password = function()
+        return nil
+      end
+      vim.env.OPENCODE_SERVER_PASSWORD = 'envpass'
+      local headers = auth.get_auth_headers()
+      assert.equals('Basic ' .. vim.base64.encode('opencode:envpass'), headers['Authorization'])
+    end)
+
+    it('function returning empty string falls through to env var', function()
+      config.values.server.password = function()
+        return ''
+      end
+      vim.env.OPENCODE_SERVER_PASSWORD = 'envpass'
+      local headers = auth.get_auth_headers()
+      assert.equals('Basic ' .. vim.base64.encode('opencode:envpass'), headers['Authorization'])
+    end)
+
+    it('function that errors falls through to env var', function()
+      config.values.server.password = function()
+        error('file not found')
+      end
+      vim.env.OPENCODE_SERVER_PASSWORD = 'envpass'
+      local headers = auth.get_auth_headers()
+      assert.equals('Basic ' .. vim.base64.encode('opencode:envpass'), headers['Authorization'])
+    end)
+
+    it('function username nil falls through to env var', function()
+      config.values.server.password = 'secret'
+      config.values.server.username = function()
+        return nil
+      end
+      vim.env.OPENCODE_SERVER_USERNAME = 'envuser'
+      local headers = auth.get_auth_headers()
+      local decoded = vim.base64.decode(headers['Authorization']:match('Basic (.+)'))
+      assert.equals('envuser:secret', decoded)
+    end)
+  end)
+
+  describe('caching', function()
+    it('caches resolved credentials across calls', function()
+      config.values.server.password = 'secret'
+      config.values.server.username = 'admin'
+      local headers1 = auth.get_auth_headers()
+      local headers2 = auth.get_auth_headers()
+      assert.same(headers1, headers2)
+    end)
+
+    it('does not re-evaluate config after cache is populated', function()
+      local call_count = 0
+      config.values.server.password = function()
+        call_count = call_count + 1
+        return 'pass' .. tostring(call_count)
+      end
+
+      local h1 = auth.get_auth_headers()
+      local h2 = auth.get_auth_headers()
+      assert.equals(1, call_count)
+      assert.same(h1, h2)
+    end)
+
+    it('clear_cache resets and re-resolves', function()
+      config.values.server.password = 'first'
+      auth.get_auth_headers()
+
+      config.values.server.password = 'second'
+      auth.clear_cache()
+      local headers = auth.get_auth_headers()
+      assert.equals('Basic ' .. vim.base64.encode('opencode:second'), headers['Authorization'])
+    end)
+  end)
+
+  describe('get_env', function()
+    it('returns empty table when no password is configured', function()
+      local env = auth.get_env()
+      assert.same({}, env)
+    end)
+
+    it('returns empty table when password is empty string', function()
+      config.values.server.password = ''
+      local env = auth.get_env()
+      assert.same({}, env)
+    end)
+
+    it('returns env vars when password is in config', function()
+      config.values.server.password = 'secret'
+      config.values.server.username = 'admin'
+      local env = auth.get_env()
+      assert.equals('secret', env.OPENCODE_SERVER_PASSWORD)
+      assert.equals('admin', env.OPENCODE_SERVER_USERNAME)
+    end)
+
+    it('defaults username to "opencode" when not configured', function()
+      config.values.server.password = 'secret'
+      local env = auth.get_env()
+      assert.equals('secret', env.OPENCODE_SERVER_PASSWORD)
+      assert.equals('opencode', env.OPENCODE_SERVER_USERNAME)
+    end)
+
+    it('falls back to OPENCODE_SERVER_PASSWORD env var', function()
+      vim.env.OPENCODE_SERVER_PASSWORD = 'envpass'
+      local env = auth.get_env()
+      assert.equals('envpass', env.OPENCODE_SERVER_PASSWORD)
+    end)
+
+    it('falls back to OPENCODE_SERVER_USERNAME env var', function()
+      config.values.server.password = 'secret'
+      vim.env.OPENCODE_SERVER_USERNAME = 'envuser'
+      local env = auth.get_env()
+      assert.equals('envuser', env.OPENCODE_SERVER_USERNAME)
+    end)
+
+    it('config values take precedence over env vars', function()
+      config.values.server.username = 'cfguser'
+      config.values.server.password = 'cfgpass'
+      vim.env.OPENCODE_SERVER_USERNAME = 'envuser'
+      vim.env.OPENCODE_SERVER_PASSWORD = 'envpass'
+      local env = auth.get_env()
+      assert.equals('cfgpass', env.OPENCODE_SERVER_PASSWORD)
+      assert.equals('cfguser', env.OPENCODE_SERVER_USERNAME)
+    end)
+
+    it('resolves password from a function', function()
+      config.values.server.password = function()
+        return 'funcpass'
+      end
+      local env = auth.get_env()
+      assert.equals('funcpass', env.OPENCODE_SERVER_PASSWORD)
+    end)
+
+    it('resolves username from a function', function()
+      config.values.server.password = 'secret'
+      config.values.server.username = function()
+        return 'funcuser'
+      end
+      local env = auth.get_env()
+      assert.equals('funcuser', env.OPENCODE_SERVER_USERNAME)
+    end)
+  end)
+end)

--- a/tests/unit/opencode_server_spec.lua
+++ b/tests/unit/opencode_server_spec.lua
@@ -48,6 +48,93 @@ describe('opencode.opencode_server', function()
     assert.equals('http://127.0.0.1:7777', server.url)
   end)
 
+  it('spawn passes auth env vars to vim.system when password is configured', function()
+    local config = require('opencode.config')
+    local auth = require('opencode.auth')
+    auth.clear_cache()
+    local original_password = config.values.server.password
+    local original_username = config.values.server.username
+    config.values.server.password = 'secret'
+    config.values.server.username = 'admin'
+
+    local captured_opts
+    vim.system = function(cmd, opts)
+      captured_opts = opts
+      vim.schedule(function()
+        opts.stdout(nil, 'opencode server listening on http://127.0.0.1:7777')
+      end)
+      return { pid = 1, kill = function() end }
+    end
+
+    local server = OpencodeServer.new()
+    server:spawn({
+      cwd = '.',
+      on_ready = function() end,
+      on_error = function() end,
+      on_exit = function() end,
+    })
+
+    vim.wait(100, function()
+      return captured_opts ~= nil
+    end)
+
+    assert.is_not_nil(captured_opts)
+    assert.is_not_nil(captured_opts.env)
+    assert.equals('secret', captured_opts.env.OPENCODE_SERVER_PASSWORD)
+    assert.equals('admin', captured_opts.env.OPENCODE_SERVER_USERNAME)
+
+    config.values.server.password = original_password
+    config.values.server.username = original_username
+  end)
+
+  it('spawn passes empty env when no password is configured', function()
+    local config = require('opencode.config')
+    local auth = require('opencode.auth')
+    auth.clear_cache()
+    local original_password = config.values.server.password
+    local original_env_password = vim.env.OPENCODE_SERVER_PASSWORD
+    local original_env_username = vim.env.OPENCODE_SERVER_USERNAME
+    config.values.server.password = nil
+    vim.env.OPENCODE_SERVER_PASSWORD = nil
+    vim.env.OPENCODE_SERVER_USERNAME = nil
+
+    local captured_opts
+    vim.system = function(cmd, opts)
+      captured_opts = opts
+      vim.schedule(function()
+        opts.stdout(nil, 'opencode server listening on http://127.0.0.1:7777')
+      end)
+      return { pid = 1, kill = function() end }
+    end
+
+    local server = OpencodeServer.new()
+    server:spawn({
+      cwd = '.',
+      on_ready = function() end,
+      on_error = function() end,
+      on_exit = function() end,
+    })
+
+    vim.wait(100, function()
+      return captured_opts ~= nil
+    end)
+
+    assert.is_not_nil(captured_opts)
+    assert.same({}, captured_opts.env)
+
+    config.values.server.password = original_password
+    if original_env_password then
+      vim.env.OPENCODE_SERVER_PASSWORD = original_env_password
+    else
+      vim.env.OPENCODE_SERVER_PASSWORD = nil
+    end
+    if original_env_username then
+      vim.env.OPENCODE_SERVER_USERNAME = original_env_username
+    else
+      vim.env.OPENCODE_SERVER_USERNAME = nil
+    end
+  end)
+
   it('shutdown resolves shutdown_promise and clears fields', function()
     local server = OpencodeServer.new()
     local exit_callback
@@ -385,6 +472,95 @@ describe('opencode.opencode_server', function()
 
       assert.equals(1000, captured.timeout)
       assert.equals('', captured.proxy)
+    end)
+  end)
+
+  describe('authentication headers', function()
+    local config
+    local auth = require('opencode.auth')
+    local original_password
+    local original_username
+    local original_env_password
+    local original_env_username
+
+    before_each(function()
+      auth.clear_cache()
+      config = require('opencode.config')
+      original_password = config.values.server.password
+      original_username = config.values.server.username
+      original_env_password = vim.env.OPENCODE_SERVER_PASSWORD
+      original_env_username = vim.env.OPENCODE_SERVER_USERNAME
+      config.values.server.password = nil
+      config.values.server.username = nil
+      vim.env.OPENCODE_SERVER_PASSWORD = nil
+      vim.env.OPENCODE_SERVER_USERNAME = nil
+    end)
+
+    after_each(function()
+      config.values.server.password = original_password
+      config.values.server.username = original_username
+      if original_env_password then
+        vim.env.OPENCODE_SERVER_PASSWORD = original_env_password
+      else
+        vim.env.OPENCODE_SERVER_PASSWORD = nil
+      end
+      if original_env_username then
+        vim.env.OPENCODE_SERVER_USERNAME = original_env_username
+      else
+        vim.env.OPENCODE_SERVER_USERNAME = nil
+      end
+    end)
+
+    it('health_check includes Authorization header when password is set', function()
+      config.values.server.password = 'secret'
+      local captured
+      curl.request = function(opts)
+        captured = opts
+      end
+
+      OpencodeServer.health_check('http://127.0.0.1:3000/global/health', 2000)
+
+      assert.is_not_nil(captured)
+      assert.is_not_nil(captured.headers)
+      assert.truthy(vim.startswith(captured.headers['Authorization'], 'Basic '))
+    end)
+
+    it('health_check does not include Authorization header when no password', function()
+      local captured
+      curl.request = function(opts)
+        captured = opts
+      end
+
+      OpencodeServer.health_check('http://127.0.0.1:3000/global/health', 2000)
+
+      assert.is_not_nil(captured)
+      assert.is_nil(captured.headers['Authorization'])
+    end)
+
+    it('request_graceful_shutdown includes Authorization header when password is set', function()
+      config.values.server.password = 'secret'
+      local captured
+      curl.request = function(opts)
+        captured = opts
+      end
+
+      OpencodeServer.request_graceful_shutdown('http://127.0.0.1:3000')
+
+      assert.is_not_nil(captured)
+      assert.is_not_nil(captured.headers)
+      assert.truthy(vim.startswith(captured.headers['Authorization'], 'Basic '))
+    end)
+
+    it('request_graceful_shutdown does not include Authorization header when no password', function()
+      local captured
+      curl.request = function(opts)
+        captured = opts
+      end
+
+      OpencodeServer.request_graceful_shutdown('http://127.0.0.1:3000')
+
+      assert.is_not_nil(captured)
+      assert.is_nil(captured.headers['Authorization'])
     end)
   end)
 end)

--- a/tests/unit/server_job_spec.lua
+++ b/tests/unit/server_job_spec.lua
@@ -399,4 +399,103 @@ describe('server_job', function()
       vim.defer_fn = original_defer_fn
     end)
   end)
+
+  describe('authentication headers', function()
+    local config = require('opencode.config')
+    local auth = require('opencode.auth')
+    local original_password
+    local original_username
+    local original_env_password
+    local original_env_username
+
+    before_each(function()
+      auth.clear_cache()
+      original_password = config.values.server.password
+      original_username = config.values.server.username
+      original_env_password = vim.env.OPENCODE_SERVER_PASSWORD
+      original_env_username = vim.env.OPENCODE_SERVER_USERNAME
+      config.values.server.password = nil
+      config.values.server.username = nil
+      vim.env.OPENCODE_SERVER_PASSWORD = nil
+      vim.env.OPENCODE_SERVER_USERNAME = nil
+    end)
+
+    after_each(function()
+      config.values.server.password = original_password
+      config.values.server.username = original_username
+      if original_env_password then
+        vim.env.OPENCODE_SERVER_PASSWORD = original_env_password
+      else
+        vim.env.OPENCODE_SERVER_PASSWORD = nil
+      end
+      if original_env_username then
+        vim.env.OPENCODE_SERVER_USERNAME = original_env_username
+      else
+        vim.env.OPENCODE_SERVER_USERNAME = nil
+      end
+    end)
+
+    it('call_api includes Authorization header when password is set', function()
+      config.values.server.password = 'secret'
+      config.values.server.username = 'testuser'
+
+      local captured_opts
+      curl.request = function(opts)
+        captured_opts = opts
+        vim.schedule(function()
+          opts.callback({ status = 200, body = '{}' })
+        end)
+      end
+
+      server_job.call_api('http://localhost:1234/test', 'GET'):wait()
+
+      assert.is_not_nil(captured_opts)
+      assert.is_not_nil(captured_opts.headers)
+      assert.truthy(vim.startswith(captured_opts.headers['Authorization'], 'Basic '))
+    end)
+
+    it('call_api does not include Authorization header when no password', function()
+      local captured_opts
+      curl.request = function(opts)
+        captured_opts = opts
+        vim.schedule(function()
+          opts.callback({ status = 200, body = '{}' })
+        end)
+      end
+
+      server_job.call_api('http://localhost:1234/test', 'GET'):wait()
+
+      assert.is_not_nil(captured_opts)
+      assert.is_nil(captured_opts.headers['Authorization'])
+    end)
+
+    it('stream_api includes Authorization header when password is set', function()
+      config.values.server.password = 'secret'
+
+      local captured_opts
+      curl.request = function(opts)
+        captured_opts = opts
+        return { pid = 1 }
+      end
+
+      server_job.stream_api('http://localhost:1234/stream', 'GET', nil, function() end)
+
+      assert.is_not_nil(captured_opts)
+      assert.is_not_nil(captured_opts.headers)
+      assert.truthy(vim.startswith(captured_opts.headers['Authorization'], 'Basic '))
+    end)
+
+    it('stream_api does not include Authorization header when no password', function()
+      local captured_opts
+      curl.request = function(opts)
+        captured_opts = opts
+        return { pid = 1 }
+      end
+
+      server_job.stream_api('http://localhost:1234/stream', 'GET', nil, function() end)
+
+      assert.is_not_nil(captured_opts)
+      assert.is_nil(captured_opts.headers['Authorization'])
+    end)
+  end)
 end)


### PR DESCRIPTION
Noticed a comment about [eventually looking in to support for username / passwords on remotes](https://github.com/sudo-tee/opencode.nvim/pull/295#issuecomment-3992146786), and since have my opencode behind a username / password, decided to add support for it.

All tests pass and it works locally.


https://github.com/user-attachments/assets/f2929efc-bcf6-4d00-8866-789dd240777f

