### PR TITLE
fix(ui): stabilize custom question input and dialog restoration

### DIFF
--- a/lua/opencode/keymap.lua
+++ b/lua/opencode/keymap.lua
@@ -1,6 +1,10 @@
 local M = {}
 local commands = require('opencode.commands')
 
+local function normalize_lhs(lhs)
+  return vim.api.nvim_replace_termcodes(lhs, true, true, true)
+end
+
 local function is_completion_visible()
   return require('opencode.ui.completion').is_completion_visible()
 end
@@ -44,7 +48,8 @@ end
 ---@param keymap_config table The keymap configuration table
 ---@param default_modes table Default modes for these keymaps
 ---@param base_opts table Base options to use for all keymaps
-local function process_keymap_entry(keymap_config, default_modes, base_opts)
+---@param preserve_existing? boolean
+local function process_keymap_entry(keymap_config, default_modes, base_opts, preserve_existing)
   local command_defs = commands.get_commands()
 
   for key_binding, config_entry in pairs(keymap_config) do
@@ -56,10 +61,26 @@ local function process_keymap_entry(keymap_config, default_modes, base_opts)
       local callback = resolve_callback(func_name, func_args)
 
       local modes = config_entry.mode or default_modes
+      if preserve_existing and base_opts.buffer then
+        local missing_modes = {}
+        for _, mode in ipairs(type(modes) == 'table' and modes or { modes }) do
+          local exists = false
+          for _, mapping in ipairs(vim.api.nvim_buf_get_keymap(base_opts.buffer, mode)) do
+            if normalize_lhs(mapping.lhs) == normalize_lhs(key_binding) then
+              exists = true
+              break
+            end
+          end
+          if not exists then
+            table.insert(missing_modes, mode)
+          end
+        end
+        modes = missing_modes
+      end
       local opts = vim.tbl_deep_extend('force', {}, base_opts)
       opts.desc = config_entry.desc or vim.tbl_get(command_defs, func_name, 'desc') or ''
 
-      if callback then
+      if callback and #modes > 0 then
         if config_entry.defer_to_completion then
           callback = wrap_with_completion_check(key_binding, callback)
         end
@@ -78,12 +99,13 @@ end
 
 ---@param keymap_config table Window keymap configuration
 ---@param buf_id integer Buffer ID to set keymaps for
-function M.setup_window_keymaps(keymap_config, buf_id)
+---@param preserve_existing? boolean
+function M.setup_window_keymaps(keymap_config, buf_id, preserve_existing)
   if not vim.api.nvim_buf_is_valid(buf_id) then
     return
   end
 
-  process_keymap_entry(keymap_config or {}, { 'n' }, { silent = true, buffer = buf_id })
+  process_keymap_entry(keymap_config or {}, { 'n' }, { silent = true, buffer = buf_id }, preserve_existing)
 end
 
 return M

--- a/lua/opencode/ui/inline_input.lua
+++ b/lua/opencode/ui/inline_input.lua
@@ -19,14 +19,15 @@ function M.open(opts)
   local anchor = vim.fn.screenpos(opts.win, opts.row + 1, opts.col + 1)
   local width = math.max(1, math.min(50, vim.o.columns - anchor.col - 1))
   local max_height = math.max(1, vim.o.lines - anchor.row - 2)
+  local initial_lines = opts.initial_text and vim.split(opts.initial_text, '\n', { plain = true }) or nil
 
   local buf = vim.api.nvim_create_buf(false, true)
   vim.bo[buf].buftype = 'prompt'
   vim.bo[buf].bufhidden = 'wipe'
   vim.fn.prompt_setprompt(buf, '')
 
-  if opts.initial_text then
-    vim.api.nvim_buf_set_lines(buf, 0, 1, false, { opts.initial_text })
+  if initial_lines then
+    vim.api.nvim_buf_set_lines(buf, 0, 1, false, initial_lines)
   end
 
   local win = vim.api.nvim_open_win(buf, true, {
@@ -48,7 +49,8 @@ function M.open(opts)
       return
     end
 
-    local height = vim.api.nvim_win_text_height(win, { start_row = 0, end_row = 0 }).all
+    local line_count = vim.api.nvim_buf_line_count(buf)
+    local height = vim.api.nvim_win_text_height(win, { start_row = 0, end_row = line_count - 1 }).all
     vim.api.nvim_win_set_config(win, { height = math.min(max_height, math.max(1, height)) })
   end
 
@@ -71,6 +73,15 @@ function M.open(opts)
     end)
   end
 
+  local function cancel_with_draft()
+    local text = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), '\n')
+    close()
+    if opts.on_leave then
+      opts.on_leave(text)
+    end
+    opts.on_cancel()
+  end
+
   vim.fn.prompt_setcallback(buf, function(text)
     close()
     if text ~= '' then
@@ -81,19 +92,17 @@ function M.open(opts)
   end)
 
   vim.keymap.set('i', '<C-c>', function()
-    close()
-    opts.on_cancel()
+    cancel_with_draft()
   end, { buffer = buf, silent = true, nowait = true })
 
   vim.keymap.set('n', '<Esc>', function()
-    close()
-    opts.on_cancel()
+    cancel_with_draft()
   end, { buffer = buf, silent = true, nowait = true })
 
-  vim.api.nvim_create_autocmd('TextChangedI', {
+  vim.api.nvim_create_autocmd({ 'TextChanged', 'TextChangedI' }, {
     buffer = buf,
     callback = function()
-      resize_height()
+      vim.schedule(resize_height)
     end,
   })
 
@@ -118,12 +127,7 @@ function M.open(opts)
     buffer = buf,
     callback = function()
       if not closed then
-        local line = vim.api.nvim_buf_get_lines(buf, 0, 1, false)[1] or ''
-        close()
-        if opts.on_leave then
-          opts.on_leave(line)
-        end
-        opts.on_cancel()
+        cancel_with_draft()
       end
     end,
   })
@@ -132,8 +136,9 @@ function M.open(opts)
     if vim.api.nvim_win_is_valid(win) then
       vim.api.nvim_set_current_win(win)
       vim.cmd.startinsert()
-      if opts.initial_text then
-        vim.api.nvim_win_set_cursor(win, { 1, vim.fn.strlen(opts.initial_text) })
+      if initial_lines then
+        local last_line = initial_lines[#initial_lines]
+        vim.api.nvim_win_set_cursor(win, { #initial_lines, vim.fn.strlen(last_line) })
       end
     end
   end)

--- a/lua/opencode/ui/inline_input.lua
+++ b/lua/opencode/ui/inline_input.lua
@@ -4,8 +4,6 @@ local M = {}
 ---@field win integer            -- window to anchor against
 ---@field row integer            -- 0-indexed row in that window's buffer
 ---@field col integer            -- 0-indexed col in that window's buffer
----@field min_width? integer
----@field max_width? integer
 ---@field title? string           -- window border title
 ---@field initial_text? string
 ---@field on_submit fun(text: string)
@@ -18,8 +16,9 @@ local M = {}
 ---@param opts InlineInputOpts
 ---@return { close: fun(), win: integer, buf: integer }
 function M.open(opts)
-  local min_width = opts.min_width or 50
-  local max_width = opts.max_width or 75
+  local anchor = vim.fn.screenpos(opts.win, opts.row + 1, opts.col + 1)
+  local width = math.max(1, math.min(50, vim.o.columns - anchor.col - 1))
+  local max_height = math.max(1, vim.o.lines - anchor.row - 2)
 
   local buf = vim.api.nvim_create_buf(false, true)
   vim.bo[buf].buftype = 'prompt'
@@ -34,7 +33,7 @@ function M.open(opts)
     relative = 'win',
     win = opts.win,
     bufpos = { opts.row, opts.col },
-    width = min_width,
+    width = width,
     height = 1,
     style = 'minimal',
     border = 'rounded',
@@ -42,6 +41,18 @@ function M.open(opts)
     title_pos = opts.title and 'left' or nil,
     zindex = 60,
   })
+  vim.wo[win].wrap = true
+
+  local function resize_height()
+    if not vim.api.nvim_win_is_valid(win) then
+      return
+    end
+
+    local height = vim.api.nvim_win_text_height(win, { start_row = 0, end_row = 0 }).all
+    vim.api.nvim_win_set_config(win, { height = math.min(max_height, math.max(1, height)) })
+  end
+
+  resize_height()
 
   local closed = false
   local function close()
@@ -82,12 +93,7 @@ function M.open(opts)
   vim.api.nvim_create_autocmd('TextChangedI', {
     buffer = buf,
     callback = function()
-      if not vim.api.nvim_win_is_valid(win) then
-        return
-      end
-      local line = vim.api.nvim_buf_get_lines(buf, 0, 1, false)[1] or ''
-      local width = math.min(max_width, math.max(min_width, vim.fn.strdisplaywidth(line) + 2))
-      vim.api.nvim_win_set_config(win, { width = width })
+      resize_height()
     end,
   })
 

--- a/lua/opencode/ui/inline_input.lua
+++ b/lua/opencode/ui/inline_input.lua
@@ -18,7 +18,9 @@ local M = {}
 function M.open(opts)
   local anchor = vim.fn.screenpos(opts.win, opts.row + 1, opts.col + 1)
   local width = math.max(1, math.min(50, vim.o.columns - anchor.col - 1))
-  local max_height = math.max(1, vim.o.lines - anchor.row - 2)
+  local col_shift = math.max(0, anchor.col + width + 1 - vim.o.columns)
+  local row_shift = math.max(0, anchor.row + 3 - vim.o.lines)
+  local max_height = math.max(1, vim.o.lines - anchor.row + row_shift - 2)
   local initial_lines = opts.initial_text and vim.split(opts.initial_text, '\n', { plain = true }) or nil
 
   local buf = vim.api.nvim_create_buf(false, true)
@@ -34,6 +36,8 @@ function M.open(opts)
     relative = 'win',
     win = opts.win,
     bufpos = { opts.row, opts.col },
+    row = 1 - row_shift,
+    col = -col_shift,
     width = width,
     height = 1,
     style = 'minimal',
@@ -57,11 +61,20 @@ function M.open(opts)
   resize_height()
 
   local closed = false
+  local win_closed_autocmd
+  local function delete_win_closed_autocmd()
+    if win_closed_autocmd then
+      pcall(vim.api.nvim_del_autocmd, win_closed_autocmd)
+      win_closed_autocmd = nil
+    end
+  end
+
   local function close()
     if closed then
       return
     end
     closed = true
+    delete_win_closed_autocmd()
     if vim.api.nvim_win_is_valid(win) then
       vim.api.nvim_win_close(win, true)
     end
@@ -106,13 +119,18 @@ function M.open(opts)
     end,
   })
 
-  vim.api.nvim_create_autocmd('WinClosed', {
-    pattern = tostring(win),
-    callback = function()
+  win_closed_autocmd = vim.api.nvim_create_autocmd('WinClosed', {
+    pattern = { tostring(opts.win), tostring(win) },
+    callback = function(event)
       if closed then
         return
       end
+      if tonumber(event.match) == opts.win then
+        cancel_with_draft()
+        return
+      end
       closed = true
+      delete_win_closed_autocmd()
       if vim.api.nvim_win_is_valid(opts.win) then
         vim.api.nvim_set_current_win(opts.win)
       end

--- a/lua/opencode/ui/output_window.lua
+++ b/lua/opencode/ui/output_window.lua
@@ -300,7 +300,6 @@ function M.setup(windows)
   M.update_dimensions(windows)
   M.reset_scroll_tracking(windows.output_win)
   M._last_visible_bottom_by_win[windows.output_win] = M.get_visible_bottom_line(windows.output_win)
-  M.setup_keymaps(windows)
 end
 
 ---@param windows OpencodeWindowState?
@@ -681,18 +680,30 @@ function M.close()
 end
 
 ---@param windows OpencodeWindowState
-function M.setup_keymaps(windows)
+---@param preserve_existing? boolean
+function M.setup_keymaps(windows, preserve_existing)
   local keymap = require('opencode.keymap')
-  keymap.setup_window_keymaps(config.keymap.output_window, windows.output_buf)
+  keymap.setup_window_keymaps(config.keymap.output_window, windows.output_buf, preserve_existing)
 
   -- When lazy-render is active, gg only reaches the top of rendered content.
   -- Load all messages first so gg reaches the true start of history.
-  vim.keymap.set('n', 'gg', function()
-    local renderer = require('opencode.ui.renderer')
-    renderer.load_all_messages()
-    pcall(vim.cmd, [[noau normal! m']])
-    vim.api.nvim_win_set_cursor(0, { 1, 0 })
-  end, { buffer = windows.output_buf })
+  local has_gg = false
+  if preserve_existing then
+    for _, mapping in ipairs(vim.api.nvim_buf_get_keymap(windows.output_buf, 'n')) do
+      if mapping.lhs == 'gg' then
+        has_gg = true
+        break
+      end
+    end
+  end
+  if not has_gg then
+    vim.keymap.set('n', 'gg', function()
+      local renderer = require('opencode.ui.renderer')
+      renderer.load_all_messages()
+      pcall(vim.cmd, [[noau normal! m']])
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    end, { buffer = windows.output_buf })
+  end
 end
 
 ---@param windows OpencodeWindowState

--- a/lua/opencode/ui/question_window.lua
+++ b/lua/opencode/ui/question_window.lua
@@ -221,6 +221,23 @@ function M.show_question(question_request)
   render_question()
 end
 
+---@return boolean
+function M.restore_active_question_ui()
+  local question = M._current_question
+  if
+    not question
+    or not session_scope.belongs_to_active_session(question)
+    or is_resolved_question_request(question)
+    or M.uses_vim_ui_select(question)
+  then
+    return false
+  end
+
+  M._setup_dialog()
+  render_question()
+  return true
+end
+
 ---@param session_id string|nil
 function M.restore_pending_question(session_id)
   if not state.api_client or not session_id or session_id == '' then
@@ -229,6 +246,7 @@ function M.restore_pending_question(session_id)
 
   if M.has_question() and session_scope.belongs_to_active_session(M._current_question) then
     if not is_resolved_question_request(M._current_question) then
+      M.restore_active_question_ui()
       return Promise.new():resolve(nil)
     end
 

--- a/lua/opencode/ui/question_window.lua
+++ b/lua/opencode/ui/question_window.lua
@@ -459,6 +459,55 @@ function M._submit_multi_answers(request_id, question_index)
   end, 100)
 end
 
+---@param request_id string
+---@param question_index integer
+---@param option_index integer|nil
+---@param on_submit fun(text: string)
+---@return boolean
+local function open_inline_other_input(request_id, question_index, option_index, on_submit)
+  if config.ui.questions.inline_other_input == false or not option_index then
+    return false
+  end
+
+  local pos = M._dialog and M._dialog:get_option_position(option_index)
+  local part_data = require('opencode.ui.renderer.ctx').render_state:get_part('question-display-part')
+  if not (pos and part_data and part_data.line_start and state.windows and state.windows.output_win) then
+    return false
+  end
+
+  M._clear_inline_input()
+  local handle
+  handle = require('opencode.ui.inline_input').open({
+    win = state.windows.output_win,
+    row = part_data.line_start + pos.line,
+    col = pos.col,
+    title = 'Type your answer',
+    initial_text = M._other_input_drafts[question_index],
+    on_submit = function(text)
+      if M._inline_input == handle then
+        M._inline_input = nil
+      end
+      M._other_input_drafts[question_index] = nil
+      if is_active_question(request_id, question_index) then
+        on_submit(text)
+      end
+    end,
+    on_cancel = function()
+      if M._inline_input == handle then
+        M._inline_input = nil
+      end
+      if is_active_question(request_id, question_index) then
+        render_question()
+      end
+    end,
+    on_leave = function(text)
+      M._other_input_drafts[question_index] = text
+    end,
+  })
+  M._inline_input = handle
+  return true
+end
+
 ---Open inline input for multi-select "Other" custom answer
 ---@param request_id string
 ---@param question_index integer
@@ -467,65 +516,33 @@ function M._open_multi_other_input(request_id, question_index)
     return
   end
 
-  local request = M._current_question
   local question_info = M.get_current_question_info()
-  if not request or not question_info then
+  if not question_info then
     return
   end
 
   M._empty_confirm_armed = false
 
-  local use_inline = config.ui.questions.inline_other_input ~= false
-  local custom_option_index = get_custom_option_index(question_info)
-  local pos = use_inline and custom_option_index and M._dialog and M._dialog:get_option_position(custom_option_index)
-  local part_data = use_inline and require('opencode.ui.renderer.ctx').render_state:get_part('question-display-part')
-
-  if use_inline and pos and part_data and part_data.line_start and state.windows and state.windows.output_win then
-    M._clear_inline_input()
-    local handle
-    handle = require('opencode.ui.inline_input').open({
-      win = state.windows.output_win,
-      row = part_data.line_start + pos.line,
-      col = pos.col,
-      title = 'Type your answer',
-      initial_text = M._other_input_drafts[question_index],
-      on_submit = function(text)
-        if M._inline_input == handle then
-          M._inline_input = nil
-        end
-        M._other_input_drafts[question_index] = nil
-        if not is_active_question(request_id, question_index) then
-          return
-        end
-        M._multi_selections[question_index] = M._multi_selections[question_index] or {}
-        M._multi_selections[question_index].custom_answer = text
-        render_question()
-      end,
-      on_cancel = function()
-        if M._inline_input == handle then
-          M._inline_input = nil
-        end
-        if is_active_question(request_id, question_index) then
-          render_question()
-        end
-      end,
-      on_leave = function(text)
-        M._other_input_drafts[question_index] = text
-      end,
-    })
-    M._inline_input = handle
-  else
-    vim.ui.input({ prompt = 'Enter your response: ' }, function(input)
-      if not is_active_question(request_id, question_index) then
-        return
-      end
-      if input and input ~= '' then
-        M._multi_selections[question_index] = M._multi_selections[question_index] or {}
-        M._multi_selections[question_index].custom_answer = input
-      end
+  if
+    open_inline_other_input(request_id, question_index, get_custom_option_index(question_info), function(text)
+      M._multi_selections[question_index] = M._multi_selections[question_index] or {}
+      M._multi_selections[question_index].custom_answer = text
       render_question()
     end)
+  then
+    return
   end
+
+  vim.ui.input({ prompt = 'Enter your response: ' }, function(input)
+    if not is_active_question(request_id, question_index) then
+      return
+    end
+    if input and input ~= '' then
+      M._multi_selections[question_index] = M._multi_selections[question_index] or {}
+      M._multi_selections[question_index].custom_answer = input
+    end
+    render_question()
+  end)
 end
 
 ---Prompt for a free-form answer to the active question.
@@ -688,53 +705,13 @@ local function handle_other_option_inline(index, request_id, question_index)
   local question_info = M.get_current_question_info()
   local custom_option_index = question_info and get_custom_option_index(question_info)
 
-  if not (index == custom_option_index and config.ui.questions.inline_other_input ~= false) then
+  if index ~= custom_option_index then
     return false
   end
 
-  local pos = M._dialog and M._dialog:get_option_position(index)
-  local part_data = require('opencode.ui.renderer.ctx').render_state:get_part('question-display-part')
-
-  if not (pos and part_data and part_data.line_start and state.windows and state.windows.output_win) then
-    return false
-  end
-
-  M._clear_inline_input()
-  local handle
-  handle = require('opencode.ui.inline_input').open({
-    win = state.windows.output_win,
-    row = part_data.line_start + pos.line,
-    col = pos.col,
-    title = 'Type your answer',
-    initial_text = M._other_input_drafts[question_index],
-    on_submit = function(text)
-      if M._inline_input == handle then
-        M._inline_input = nil
-      end
-      M._other_input_drafts[question_index] = nil
-      if not is_active_question(request_id, question_index) then
-        return
-      end
-      if text and text ~= '' then
-        answer_current_question(text, request_id, question_index)
-      else
-        render_question()
-      end
-    end,
-    on_cancel = function()
-      if M._inline_input == handle then
-        M._inline_input = nil
-      end
-      if is_active_question(request_id, question_index) then
-        render_question()
-      end
-    end,
-    on_leave = function(text)
-      M._other_input_drafts[question_index] = text
-    end,
-  })
-  M._inline_input = handle
-  return true
+  return open_inline_other_input(request_id, question_index, index, function(text)
+    answer_current_question(text, request_id, question_index)
+  end)
 end
 
 ---Create the in-buffer dialog used to answer the active question.

--- a/lua/opencode/ui/question_window.lua
+++ b/lua/opencode/ui/question_window.lua
@@ -222,7 +222,7 @@ function M.show_question(question_request)
 end
 
 ---@return boolean
-function M.restore_active_question_ui()
+local function restore_active_question_ui()
   local question = M._current_question
   if
     not question
@@ -246,7 +246,7 @@ function M.restore_pending_question(session_id)
 
   if M.has_question() and session_scope.belongs_to_active_session(M._current_question) then
     if not is_resolved_question_request(M._current_question) then
-      M.restore_active_question_ui()
+      restore_active_question_ui()
       return Promise.new():resolve(nil)
     end
 

--- a/lua/opencode/ui/ui.lua
+++ b/lua/opencode/ui/ui.lua
@@ -281,6 +281,7 @@ function M.restore_hidden_windows()
   end)
 
   require('opencode.ui.contextual_actions').setup_contextual_actions(windows)
+  require('opencode.ui.question_window').restore_active_question_ui()
 
   return true
 end

--- a/lua/opencode/ui/ui.lua
+++ b/lua/opencode/ui/ui.lua
@@ -246,6 +246,7 @@ function M.restore_hidden_windows()
 
   input_window.setup(windows)
   output_window.setup(windows)
+  output_window.setup_keymaps(windows, true)
   footer.setup(windows)
   if state.api_client and type(state.api_client.list_providers) == 'function' then
     topbar.setup()
@@ -281,7 +282,6 @@ function M.restore_hidden_windows()
   end)
 
   require('opencode.ui.contextual_actions').setup_contextual_actions(windows)
-  require('opencode.ui.question_window').restore_active_question_ui()
 
   return true
 end
@@ -400,6 +400,7 @@ function M.create_windows()
 
   input_window.setup(windows)
   output_window.setup(windows)
+  output_window.setup_keymaps(windows)
   footer.setup(windows)
   topbar.setup()
 

--- a/tests/unit/inline_input_spec.lua
+++ b/tests/unit/inline_input_spec.lua
@@ -3,14 +3,8 @@ local inline_input = require('opencode.ui.inline_input')
 describe('inline_input', function()
   local anchor_buf
   local anchor_win
-  local original_schedule
 
   before_each(function()
-    original_schedule = vim.schedule
-    vim.schedule = function(callback)
-      callback()
-    end
-
     local lines = {}
     for i = 1, 10 do
       lines[i] = string.rep('a', vim.o.columns)
@@ -28,7 +22,6 @@ describe('inline_input', function()
   end)
 
   after_each(function()
-    vim.schedule = original_schedule
     if vim.api.nvim_win_is_valid(anchor_win) then
       vim.api.nvim_win_close(anchor_win, true)
     end
@@ -38,7 +31,7 @@ describe('inline_input', function()
   end)
 
   local function open_input(row, col, on_submit)
-    return inline_input.open({
+    local input = inline_input.open({
       win = anchor_win,
       row = row,
       col = col,
@@ -46,6 +39,10 @@ describe('inline_input', function()
       on_submit = on_submit or function() end,
       on_cancel = function() end,
     })
+    assert.is_true(vim.wait(50, function()
+      return vim.api.nvim_get_current_win() == input.win
+    end))
+    return input
   end
 
   local function change_text(input, text)
@@ -70,9 +67,9 @@ describe('inline_input', function()
         first_cancelled = first_cancelled + 1
       end,
     })
-    vim.wait(50, function()
+    assert.is_true(vim.wait(50, function()
       return vim.api.nvim_get_current_win() == first.win
-    end)
+    end))
     vim.api.nvim_buf_set_lines(first.buf, 0, 1, false, { 'draft from first input' })
     vim.api.nvim_set_current_win(anchor_win)
 
@@ -90,9 +87,9 @@ describe('inline_input', function()
         second_cancelled = second_cancelled + 1
       end,
     })
-    vim.wait(50, function()
+    assert.is_true(vim.wait(50, function()
       return vim.api.nvim_get_current_win() == second.win
-    end)
+    end))
 
     assert.are.same({ '' }, vim.api.nvim_buf_get_lines(second.buf, 0, 1, false))
 
@@ -114,9 +111,9 @@ describe('inline_input', function()
         cancelled = cancelled + 1
       end,
     })
-    vim.wait(50, function()
+    assert.is_true(vim.wait(50, function()
       return vim.api.nvim_get_current_win() == input.win
-    end)
+    end))
 
     assert.are.same({ 'restored draft' }, vim.api.nvim_buf_get_lines(input.buf, 0, 1, false))
 

--- a/tests/unit/inline_input_spec.lua
+++ b/tests/unit/inline_input_spec.lua
@@ -3,22 +3,55 @@ local inline_input = require('opencode.ui.inline_input')
 describe('inline_input', function()
   local anchor_buf
   local anchor_win
+  local original_schedule
 
   before_each(function()
+    original_schedule = vim.schedule
+    vim.schedule = function(callback)
+      callback()
+    end
+
+    local lines = {}
+    for i = 1, 10 do
+      lines[i] = string.rep('a', vim.o.columns)
+    end
+
     anchor_buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(anchor_buf, 0, -1, false, lines)
     anchor_win = vim.api.nvim_open_win(anchor_buf, true, {
       relative = 'editor',
-      width = 80,
-      height = 10,
       row = 0,
       col = 0,
+      width = vim.o.columns - 1,
+      height = 10,
     })
   end)
 
   after_each(function()
-    pcall(vim.api.nvim_win_close, anchor_win, true)
-    pcall(vim.api.nvim_buf_delete, anchor_buf, { force = true })
+    vim.schedule = original_schedule
+    if vim.api.nvim_win_is_valid(anchor_win) then
+      vim.api.nvim_win_close(anchor_win, true)
+    end
+    if vim.api.nvim_buf_is_valid(anchor_buf) then
+      vim.api.nvim_buf_delete(anchor_buf, { force = true })
+    end
   end)
+
+  local function open_input(row, col, on_submit)
+    return inline_input.open({
+      win = anchor_win,
+      row = row,
+      col = col,
+      title = 'Answer',
+      on_submit = on_submit or function() end,
+      on_cancel = function() end,
+    })
+  end
+
+  local function change_text(input, text)
+    vim.api.nvim_buf_set_lines(input.buf, 0, 1, false, { text })
+    vim.api.nvim_exec_autocmds('TextChangedI', { buffer = input.buf, modeline = false })
+  end
 
   it('is stateless across opens (no implicit carry-over)', function()
     local first_cancelled = 0
@@ -89,5 +122,60 @@ describe('inline_input', function()
 
     vim.api.nvim_set_current_win(anchor_win)
     assert.are.equal(1, cancelled)
+  end)
+
+  it('keeps its opening width while wrapped text grows and shrinks', function()
+    local input = open_input(0, 0)
+    local opening_width = vim.api.nvim_win_get_config(input.win).width
+
+    assert.equals(50, opening_width)
+    assert.equals(1, vim.api.nvim_win_get_config(input.win).height)
+
+    change_text(input, string.rep('a', opening_width + 1))
+
+    assert.equals(opening_width, vim.api.nvim_win_get_config(input.win).width)
+    assert.equals(2, vim.api.nvim_win_get_config(input.win).height)
+
+    change_text(input, 'short')
+
+    assert.equals(opening_width, vim.api.nvim_win_get_config(input.win).width)
+    assert.equals(1, vim.api.nvim_win_get_config(input.win).height)
+    input.close()
+  end)
+
+  it('shrinks its opening width before the right border reaches the editor edge', function()
+    local col = vim.api.nvim_win_get_width(anchor_win) - 2
+    local input = open_input(0, col)
+    local anchor = vim.fn.screenpos(anchor_win, 1, col + 1)
+    local width = vim.api.nvim_win_get_config(input.win).width
+
+    assert.equals(math.min(50, vim.o.columns - anchor.col - 1), width)
+    assert.is_true(anchor.col + width + 1 <= vim.o.columns)
+    input.close()
+  end)
+
+  it('caps its height below the screen edge while preserving wrapped text', function()
+    local row = math.min(7, vim.o.lines - 4)
+    local input = open_input(row, 0)
+    local anchor = vim.fn.screenpos(anchor_win, row + 1, 1)
+    local max_height = math.max(1, vim.o.lines - anchor.row - 2)
+
+    change_text(input, string.rep('a', 50 * (max_height + 1)))
+
+    assert.equals(max_height, vim.api.nvim_win_get_config(input.win).height)
+    assert.is_true(vim.api.nvim_win_text_height(input.win, { start_row = 0, end_row = 0 }).all > max_height)
+    input.close()
+  end)
+
+  it('submits every character from a wrapped mixed-language line', function()
+    local submitted
+    local text = 'English 中文 mixed ' .. string.rep('长文本', 40)
+
+    open_input(0, 0, function(value)
+      submitted = value
+    end)
+    vim.api.nvim_feedkeys(vim.keycode('i' .. text .. '<CR>'), 'x', false)
+
+    assert.equals(text, submitted)
   end)
 end)

--- a/tests/unit/inline_input_spec.lua
+++ b/tests/unit/inline_input_spec.lua
@@ -23,7 +23,7 @@ describe('inline_input', function()
 
   after_each(function()
     if vim.api.nvim_win_is_valid(anchor_win) then
-      vim.api.nvim_win_close(anchor_win, true)
+      pcall(vim.api.nvim_win_close, anchor_win, true)
     end
     if vim.api.nvim_buf_is_valid(anchor_buf) then
       vim.api.nvim_buf_delete(anchor_buf, { force = true })
@@ -43,6 +43,17 @@ describe('inline_input', function()
       return vim.api.nvim_get_current_win() == input.win
     end))
     return input
+  end
+
+  local function use_regular_anchor()
+    vim.api.nvim_win_close(anchor_win, true)
+    anchor_win = vim.api.nvim_get_current_win()
+    vim.api.nvim_win_set_buf(anchor_win, anchor_buf)
+    vim.wo[anchor_win].wrap = false
+    vim.wo[anchor_win].signcolumn = 'no'
+    vim.wo[anchor_win].foldcolumn = '0'
+    vim.wo[anchor_win].number = false
+    vim.wo[anchor_win].relativenumber = false
   end
 
   local function change_text(input, text, expected_height)
@@ -162,13 +173,15 @@ describe('inline_input', function()
   end)
 
   it('shrinks its opening width before the right border reaches the editor edge', function()
+    use_regular_anchor()
     local col = vim.api.nvim_win_get_width(anchor_win) - 2
     local input = open_input(0, col)
     local anchor = vim.fn.screenpos(anchor_win, 1, col + 1)
     local width = vim.api.nvim_win_get_config(input.win).width
+    local position = vim.api.nvim_win_get_position(input.win)
 
-    assert.equals(math.min(50, vim.o.columns - anchor.col - 1), width)
-    assert.is_true(anchor.col + width + 1 <= vim.o.columns)
+    assert.equals(math.max(1, math.min(50, vim.o.columns - anchor.col - 1)), width)
+    assert.is_true(position[2] + width + 2 <= vim.o.columns)
     input.close()
   end)
 
@@ -183,6 +196,47 @@ describe('inline_input', function()
     assert.equals(max_height, vim.api.nvim_win_get_config(input.win).height)
     assert.is_true(vim.api.nvim_win_text_height(input.win, { start_row = 0, end_row = 0 }).all > max_height)
     input.close()
+  end)
+
+  it('keeps its rounded border inside the editor at the bottom-right edge', function()
+    vim.api.nvim_win_close(anchor_win, true)
+    vim.cmd('botright 10vnew')
+    vim.cmd('botright 1new')
+    anchor_win = vim.api.nvim_get_current_win()
+    vim.api.nvim_win_set_buf(anchor_win, anchor_buf)
+    vim.wo[anchor_win].wrap = false
+    vim.wo[anchor_win].signcolumn = 'no'
+    vim.wo[anchor_win].foldcolumn = '0'
+
+    local col = vim.api.nvim_win_get_width(anchor_win) - 3
+    local anchor = vim.fn.screenpos(anchor_win, 1, col + 1)
+    assert.equals(vim.o.lines - 2, anchor.row)
+
+    local input = open_input(0, col)
+    local position = vim.api.nvim_win_get_position(input.win)
+    local window_config = vim.api.nvim_win_get_config(input.win)
+
+    assert.is_true(
+      position[2] + window_config.width + 2 <= vim.o.columns,
+      vim.inspect({ position = position, config = window_config, columns = vim.o.columns, lines = vim.o.lines })
+    )
+    assert.is_true(
+      position[1] + window_config.height + 2 <= vim.o.lines,
+      vim.inspect({ position = position, config = window_config, columns = vim.o.columns, lines = vim.o.lines })
+    )
+    input.close()
+    vim.cmd('only')
+  end)
+
+  it('removes its WinClosed watcher after closing', function()
+    local before = #vim.api.nvim_get_autocmds({ event = 'WinClosed' })
+
+    for _ = 1, 5 do
+      local input = open_input(0, 0)
+      input.close()
+    end
+
+    assert.equals(before, #vim.api.nvim_get_autocmds({ event = 'WinClosed' }))
   end)
 
   it('resizes after multiline text changes outside insert mode', function()
@@ -226,6 +280,34 @@ describe('inline_input', function()
     vim.api.nvim_buf_set_lines(input.buf, 0, -1, false, lines)
     vim.api.nvim_feedkeys(vim.keycode('i<C-c>'), 'x', false)
 
+    assert.equals(table.concat(lines, '\n'), draft)
+    assert.equals(1, cancelled)
+  end)
+
+  it('returns the draft and closes when its anchor window closes', function()
+    local draft
+    local cancelled = 0
+    local input = inline_input.open({
+      win = anchor_win,
+      row = 0,
+      col = 0,
+      on_submit = function() end,
+      on_cancel = function()
+        cancelled = cancelled + 1
+      end,
+      on_leave = function(text)
+        draft = text
+      end,
+    })
+    assert.is_true(vim.wait(50, function()
+      return vim.api.nvim_get_current_win() == input.win
+    end))
+
+    local lines = { 'first line', 'second line' }
+    vim.api.nvim_buf_set_lines(input.buf, 0, -1, false, lines)
+    vim.api.nvim_win_close(anchor_win, true)
+
+    assert.is_false(vim.api.nvim_win_is_valid(input.win))
     assert.equals(table.concat(lines, '\n'), draft)
     assert.equals(1, cancelled)
   end)

--- a/tests/unit/inline_input_spec.lua
+++ b/tests/unit/inline_input_spec.lua
@@ -45,9 +45,12 @@ describe('inline_input', function()
     return input
   end
 
-  local function change_text(input, text)
+  local function change_text(input, text, expected_height)
     vim.api.nvim_buf_set_lines(input.buf, 0, 1, false, { text })
     vim.api.nvim_exec_autocmds('TextChangedI', { buffer = input.buf, modeline = false })
+    assert.is_true(vim.wait(100, function()
+      return vim.api.nvim_win_get_config(input.win).height == expected_height
+    end))
   end
 
   it('is stateless across opens (no implicit carry-over)', function()
@@ -121,6 +124,24 @@ describe('inline_input', function()
     assert.are.equal(1, cancelled)
   end)
 
+  it('restores multiline initial_text and places the cursor at its end', function()
+    local input = inline_input.open({
+      win = anchor_win,
+      row = 0,
+      col = 0,
+      initial_text = 'first line\nsecond line',
+      on_submit = function() end,
+      on_cancel = function() end,
+    })
+    assert.is_true(vim.wait(50, function()
+      return vim.api.nvim_get_current_win() == input.win
+        and vim.deep_equal(vim.api.nvim_win_get_cursor(input.win), { 2, #'second line' })
+    end))
+
+    assert.are.same({ 'first line', 'second line' }, vim.api.nvim_buf_get_lines(input.buf, 0, -1, false))
+    input.close()
+  end)
+
   it('keeps its opening width while wrapped text grows and shrinks', function()
     local input = open_input(0, 0)
     local opening_width = vim.api.nvim_win_get_config(input.win).width
@@ -128,12 +149,12 @@ describe('inline_input', function()
     assert.equals(50, opening_width)
     assert.equals(1, vim.api.nvim_win_get_config(input.win).height)
 
-    change_text(input, string.rep('a', opening_width + 1))
+    change_text(input, string.rep('a', opening_width + 1), 2)
 
     assert.equals(opening_width, vim.api.nvim_win_get_config(input.win).width)
     assert.equals(2, vim.api.nvim_win_get_config(input.win).height)
 
-    change_text(input, 'short')
+    change_text(input, 'short', 1)
 
     assert.equals(opening_width, vim.api.nvim_win_get_config(input.win).width)
     assert.equals(1, vim.api.nvim_win_get_config(input.win).height)
@@ -157,11 +178,56 @@ describe('inline_input', function()
     local anchor = vim.fn.screenpos(anchor_win, row + 1, 1)
     local max_height = math.max(1, vim.o.lines - anchor.row - 2)
 
-    change_text(input, string.rep('a', 50 * (max_height + 1)))
+    change_text(input, string.rep('a', 50 * (max_height + 1)), max_height)
 
     assert.equals(max_height, vim.api.nvim_win_get_config(input.win).height)
     assert.is_true(vim.api.nvim_win_text_height(input.win, { start_row = 0, end_row = 0 }).all > max_height)
     input.close()
+  end)
+
+  it('resizes after multiline text changes outside insert mode', function()
+    local input = open_input(0, 0)
+    local lines = {
+      'local function one()',
+      '  print("one")',
+      'end',
+      'return one',
+    }
+
+    vim.api.nvim_buf_set_lines(input.buf, 0, -1, false, lines)
+    vim.api.nvim_exec_autocmds('TextChanged', { buffer = input.buf, modeline = false })
+
+    assert.is_true(vim.wait(100, function()
+      return vim.api.nvim_win_get_config(input.win).height == #lines
+    end))
+    input.close()
+  end)
+
+  it('returns the full draft when cancelled with Ctrl-C', function()
+    local draft
+    local cancelled = 0
+    local input = inline_input.open({
+      win = anchor_win,
+      row = 0,
+      col = 0,
+      on_submit = function() end,
+      on_cancel = function()
+        cancelled = cancelled + 1
+      end,
+      on_leave = function(text)
+        draft = text
+      end,
+    })
+    assert.is_true(vim.wait(50, function()
+      return vim.api.nvim_get_current_win() == input.win
+    end))
+
+    local lines = { 'local value = 1', 'return value' }
+    vim.api.nvim_buf_set_lines(input.buf, 0, -1, false, lines)
+    vim.api.nvim_feedkeys(vim.keycode('i<C-c>'), 'x', false)
+
+    assert.equals(table.concat(lines, '\n'), draft)
+    assert.equals(1, cancelled)
   end)
 
   it('submits every character from a wrapped mixed-language line', function()

--- a/tests/unit/keymap_spec.lua
+++ b/tests/unit/keymap_spec.lua
@@ -221,6 +221,27 @@ describe('opencode.keymap', function()
 
       mock_commands.execute_parsed_intent = original_execute_parsed_intent
     end)
+
+    it('preserves existing mappings across equivalent lhs notation', function()
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      local original_mapleader = vim.g.mapleader
+      vim.g.mapleader = '\\'
+
+      for _, lhs in ipairs({ '<Esc>', '<Tab>', '<C-C>', '\\x' }) do
+        original_keymap_set('n', lhs, function() end, { buffer = bufnr })
+      end
+
+      keymap.setup_window_keymaps({
+        ['<esc>'] = { function() end },
+        ['<tab>'] = { function() end },
+        ['<C-c>'] = { function() end },
+        ['<leader>x'] = { function() end },
+      }, bufnr, true)
+
+      assert.equal(0, #set_keymaps)
+      vim.g.mapleader = original_mapleader
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end)
   end)
 
   describe('defer_to_completion', function()

--- a/tests/unit/persist_state_spec.lua
+++ b/tests/unit/persist_state_spec.lua
@@ -334,6 +334,40 @@ describe('persist_state', function()
       toggle_wait('visible')
     end)
 
+    it('restores active question dialog mappings with hidden buffers', function()
+      setup_ui()
+      create_code_file()
+      state.session.set_active({ id = 'sess1' })
+      toggle_wait('visible')
+
+      local question_window = require('opencode.ui.question_window')
+      question_window.show_question({
+        id = 'question_restore_hidden',
+        sessionID = 'sess1',
+        questions = {
+          {
+            question = 'Pick one',
+            options = { { label = 'One' } },
+          },
+        },
+      })
+      require('opencode.ui.renderer.flush').flush()
+
+      toggle_wait('hidden')
+      toggle_wait('visible')
+
+      local enter_mapping
+      for _, mapping in ipairs(vim.api.nvim_buf_get_keymap(state.windows.output_buf, 'n')) do
+        if mapping.lhs == '<CR>' then
+          enter_mapping = mapping
+          break
+        end
+      end
+
+      assert.equals('Dialog: select option', enter_mapping and enter_mapping.desc)
+      question_window.clear_question()
+    end)
+
     it('fully closes when persist_state=false', function()
       setup_ui({ persist_state = false })
       create_code_file()

--- a/tests/unit/persist_state_spec.lua
+++ b/tests/unit/persist_state_spec.lua
@@ -353,19 +353,67 @@ describe('persist_state', function()
       })
       require('opencode.ui.renderer.flush').flush()
 
+      question_window._dialog:set_selection(2)
+      question_window._dialog:select()
+      assert.is_true(vim.wait(100, function()
+        return question_window._inline_input ~= nil
+      end))
+      local inline_win = question_window._inline_input.win
+      local draft_lines = { 'first line', 'second line' }
+      vim.api.nvim_buf_set_lines(question_window._inline_input.buf, 0, -1, false, draft_lines)
+
       toggle_wait('hidden')
+
+      assert.is_false(vim.api.nvim_win_is_valid(inline_win))
+      assert.is_nil(question_window._inline_input)
+      assert.equals(table.concat(draft_lines, '\n'), question_window._other_input_drafts[1])
+
       toggle_wait('visible')
 
-      local enter_mapping
+      local mappings = {}
       for _, mapping in ipairs(vim.api.nvim_buf_get_keymap(state.windows.output_buf, 'n')) do
-        if mapping.lhs == '<CR>' then
-          enter_mapping = mapping
-          break
+        mappings[mapping.lhs] = mapping
+      end
+
+      assert.equals('Dialog: select option', mappings['<CR>'] and mappings['<CR>'].desc)
+      assert.equals('Dialog: select option', mappings['<Tab>'] and mappings['<Tab>'].desc)
+      assert.equals('Dialog: dismiss', mappings['<Esc>'] and mappings['<Esc>'].desc)
+      assert.equals(2, question_window._dialog:get_selection())
+
+      question_window._dialog:select()
+      assert.is_true(vim.wait(100, function()
+        return question_window._inline_input ~= nil
+      end))
+      assert.are.same(draft_lines, vim.api.nvim_buf_get_lines(question_window._inline_input.buf, 0, -1, false))
+      question_window.clear_question()
+    end)
+
+    it('restores missing base mappings without replacing preserved mappings', function()
+      setup_ui()
+      config.keymap.output_window.a = { function() end, desc = 'Base A' }
+      create_code_file()
+      toggle_wait('visible')
+
+      local output_buf = state.windows.output_buf
+      local contextual_actions = require('opencode.ui.contextual_actions')
+      contextual_actions.show_contextual_actions_menu(output_buf, {
+        { key = 'a', text = 'Temporary A', display_line = 0 },
+      }, vim.api.nvim_create_namespace('persist-state-mapping-test'))
+
+      local function mapping_description(lhs)
+        for _, mapping in ipairs(vim.api.nvim_buf_get_keymap(output_buf, 'n')) do
+          if mapping.lhs == lhs then
+            return mapping.desc
+          end
         end
       end
 
-      assert.equals('Dialog: select option', enter_mapping and enter_mapping.desc)
-      question_window.clear_question()
+      assert.equals('Temporary A', mapping_description('a'))
+      toggle_wait('hidden')
+      assert.is_nil(mapping_description('a'))
+
+      toggle_wait('visible')
+      assert.equals('Base A', mapping_description('a'))
     end)
 
     it('fully closes when persist_state=false', function()

--- a/tests/unit/question_window_spec.lua
+++ b/tests/unit/question_window_spec.lua
@@ -975,6 +975,37 @@ describe('question_window', function()
     show_stub:revert()
   end)
 
+  it('rebuilds an unresolved dialog when restoring its UI', function()
+    helpers.replay_setup()
+    state.session.set_active({ id = 'sess1' })
+    state.jobs.set_api_client({})
+    vim.api.nvim_set_current_win(state.windows.output_win)
+
+    question_window.show_question({
+      id = 'question_restore_dialog',
+      sessionID = 'sess1',
+      questions = {
+        {
+          question = 'Pick one',
+          options = { { label = 'One' } },
+        },
+      },
+    })
+    require('opencode.ui.renderer.flush').flush()
+    question_window._dialog:teardown()
+
+    question_window.restore_pending_question('sess1'):wait()
+    require('opencode.ui.renderer.flush').flush()
+
+    assert.is_true(question_window._dialog:is_active())
+    assert.is_not_nil(question_window._dialog:get_option_position(2))
+
+    question_window.clear_question()
+    if state.windows then
+      require('opencode.ui.ui').close_windows(state.windows)
+    end
+  end)
+
   it('does not force-scroll on question navigation redraws', function()
     helpers.replay_setup()
     state.session.set_active({ id = 'sess1' })

--- a/tests/unit/question_window_spec.lua
+++ b/tests/unit/question_window_spec.lua
@@ -784,6 +784,87 @@ describe('question_window', function()
     require('opencode.ui.ui').close_windows(state.windows)
   end)
 
+  it('keeps separate custom drafts for each question and clears them for a new request', function()
+    helpers.replay_setup()
+    state.session.set_active({ id = 'sess1' })
+    vim.api.nvim_set_current_win(state.windows.output_win)
+    local flush = require('opencode.ui.renderer.flush')
+
+    local function open_other()
+      flush.flush()
+      assert.is_not_nil(require('opencode.ui.renderer.ctx').render_state:get_part('question-display-part'))
+      assert.is_not_nil(question_window._dialog:get_option_position(2))
+      question_window._dialog:set_selection(2)
+      question_window._dialog:select()
+      local input = question_window._inline_input
+      assert.is_not_nil(input)
+      vim.api.nvim_set_current_win(input.win)
+      return input.buf
+    end
+
+    local function leave_other(text)
+      local buf = open_other()
+      vim.api.nvim_buf_set_lines(buf, 0, 1, false, { text })
+      vim.api.nvim_set_current_win(state.windows.output_win)
+    end
+
+    local function read_other()
+      local buf = open_other()
+      return vim.api.nvim_buf_get_lines(buf, 0, 1, false)[1]
+    end
+
+    question_window.show_question({
+      id = 'multi-question',
+      sessionID = 'sess1',
+      questions = {
+        {
+          header = 'First',
+          question = 'First custom answer',
+          options = { { label = 'One' } },
+        },
+        {
+          header = 'Second',
+          question = 'Second custom answer',
+          options = { { label = 'Two' } },
+        },
+      },
+    })
+
+    leave_other('draft for first question')
+    question_window._dialog:navigate_group(1)
+    leave_other('draft for second question')
+
+    question_window._dialog:navigate_group(-1)
+    local first_draft = read_other()
+    vim.api.nvim_set_current_win(state.windows.output_win)
+
+    question_window._dialog:navigate_group(1)
+    local second_draft = read_other()
+    vim.api.nvim_set_current_win(state.windows.output_win)
+
+    question_window.show_question({
+      id = 'new-request',
+      sessionID = 'sess1',
+      questions = {
+        {
+          question = 'New custom answer',
+          options = { { label = 'Three' } },
+        },
+      },
+    })
+    local new_request_draft = read_other()
+
+    vim.api.nvim_set_current_win(state.windows.output_win)
+    question_window.clear_question()
+    if state.windows then
+      require('opencode.ui.ui').close_windows(state.windows)
+    end
+
+    assert.equals('draft for first question', first_draft)
+    assert.equals('draft for second question', second_draft)
+    assert.equals('', new_request_draft)
+  end)
+
   it('does not show a question that is already completed', function()
     state.renderer.set_messages({
       {


### PR DESCRIPTION
## Summary

<img width="530" height="278" alt="iShot_2026-07-15_19 17 54" src="https://github.com/user-attachments/assets/335cfbda-074c-438f-b209-d2597c3fce7a" />

I noticed that the floating window doesn't wrap text automatically, and <c-c> doesn't seem to save drafts. Here are some adjustments I've made; I'd love to hear your thoughts on them.

---

```text
Inline Custom Answer
├── Choose a fixed width when opened
│   ├── Up to 50 columns
│   └── Shrink near the right edge
├── Wrap input without changing width
├── Resize vertically with multiline content
│   └── Stop growing at the bottom edge
└── Preserve the complete draft
    ├── Submit long and multibyte text without truncation
    └── Restore multiline drafts after cancellation
```

I also did some additional code cleanup and bug fixes

- Restore the active question dialog after panel layout changes.
- Centralize the duplicated Other-input lifecycle and keep its tests on real scheduling semantics.