### PR TITLE
fix(ui): preserve mounted layout across position changes

### DIFF
--- a/docs/recipes/three-state-layout/demo.lua
+++ b/docs/recipes/three-state-layout/demo.lua
@@ -26,32 +26,34 @@ local ACTIONS = {
     if not config then
       return
     end
-    api.toggle(false)
-    config.ui.position = 'right'
-    api.toggle(false)
+    return api.toggle(false):and_then(function()
+      config.ui.position = 'right'
+      return api.toggle(false)
+    end)
   end,
   to_deep = function(api)
     local config = get_opencode_config()
     if not config then
       return
     end
-    api.toggle(false)
-    config.ui.position = 'current'
-    api.toggle(false)
+    return api.toggle(false):and_then(function()
+      config.ui.position = 'current'
+      return api.toggle(false)
+    end)
   end,
   open_side_by_side = function(api)
     local config = get_opencode_config()
     if config then
       config.ui.position = 'right'
     end
-    api.toggle(false)
+    return api.toggle(false)
   end,
   open_deep = function(api)
     local config = get_opencode_config()
     if config then
       config.ui.position = 'current'
     end
-    api.toggle(false)
+    return api.toggle(false)
   end,
 }
 
@@ -82,8 +84,7 @@ local function get_current_mode(api)
     return MODE.focused
   end
 
-  local config = get_opencode_config()
-  if config and config.ui.position == 'current' then
+  if window_state.position == 'current' then
     return MODE.deep
   end
 
@@ -103,7 +104,12 @@ local function run_transition(trigger)
   if not action then
     return
   end
-  action(api)
+  local transition = action(api)
+  if transition then
+    transition:catch(function(err)
+      vim.notify('Three-state layout transition failed: ' .. tostring(err), vim.log.levels.ERROR)
+    end)
+  end
 end
 
 -- Set up keymaps

--- a/lua/opencode/state/ui.lua
+++ b/lua/opencode/state/ui.lua
@@ -24,6 +24,7 @@ local store = require('opencode.state.store')
 ---@field input_buf integer|nil
 ---@field output_buf integer|nil
 ---@field output_was_at_bottom boolean|nil
+---@field position 'right'|'left'|'current'|'float'|nil
 
 ---@class OpencodeUiStateMutations
 local M = {}
@@ -449,10 +450,11 @@ function M.get_window_state()
 
   local status = status_rule and status_rule.status or 'closed'
   local current_windows = status_rule and status_rule.get_windows() or nil
+  local hidden = status == 'hidden' and read_hidden_buffers_snapshot(false) or nil
 
   return {
     status = status,
-    position = config.ui.position,
+    position = current_windows and current_windows.position or hidden and hidden.position or config.ui.position,
     windows = current_windows and vim.deepcopy(current_windows) or nil,
     cursor_positions = {
       input = M.get_window_cursor(current_windows and current_windows.input_win) or M.get_cursor_position('input'),

--- a/lua/opencode/ui/input_window.lua
+++ b/lua/opencode/ui/input_window.lua
@@ -56,7 +56,7 @@ local function calculate_height(windows)
 end
 
 local function apply_dimensions(windows, height)
-  if config.ui.position == 'current' then
+  if windows.position == 'current' then
     pcall(vim.api.nvim_win_set_height, windows.input_win, height)
     return
   end
@@ -88,7 +88,7 @@ function M._build_input_win_config()
 end
 
 function M.create_window(windows)
-  if config.ui.position == 'float' then
+  if windows.position == 'float' then
     local _, input_config = float_layout.window_configs(windows, true)
     windows.input_win = float_layout.open_win(windows.input_buf, true, input_config)
     return
@@ -277,7 +277,7 @@ function M.setup(windows)
   window_options.set_buffer_option('buflisted', false, windows.input_buf)
   window_options.set_buffer_option('swapfile', false, windows.input_buf)
 
-  if config.ui.position ~= 'current' then
+  if windows.position ~= 'current' then
     window_options.set_window_option('winfixbuf', true, windows.input_win)
   end
   window_options.set_window_option('winfixwidth', true, windows.input_win)
@@ -295,7 +295,7 @@ function M.update_dimensions(windows)
     return
   end
 
-  if config.ui.position == 'float' then
+  if windows.position == 'float' then
     float_layout.update(windows, true)
     return
   end
@@ -638,7 +638,7 @@ function M._hide()
   pcall(vim.api.nvim_win_close, windows.input_win, false)
   windows.input_win = nil
 
-  if config.ui.position == 'float' then
+  if windows.position == 'float' then
     float_layout.update(windows, false)
   end
 
@@ -680,7 +680,7 @@ function M._show()
     return
   end
 
-  if config.ui.position == 'float' then
+  if windows.position == 'float' then
     local output_config, input_config = float_layout.window_configs(windows, true)
     pcall(vim.api.nvim_win_set_config, output_win, output_config)
     windows.input_win = float_layout.open_win(windows.input_buf, true, input_config)

--- a/lua/opencode/ui/navigation.lua
+++ b/lua/opencode/ui/navigation.lua
@@ -196,7 +196,7 @@ function M.navigate_to_location(path, line, col)
   end
   local target_win = best_target_win()
   local windows = state.windows
-  if config.ui.position == 'current' and windows and target_win == windows.output_win then
+  if windows and windows.position == 'current' and target_win == windows.output_win then
     require('opencode.ui.ui').hide_visible_windows(windows)
   end
   return open_at(target_win, resolved_path, line, col)

--- a/lua/opencode/ui/output_window.lua
+++ b/lua/opencode/ui/output_window.lua
@@ -287,7 +287,7 @@ function M.setup(windows)
   end)
   window_options.set_window_option('foldtext', 'v:lua.opencode_fold_text()', windows.output_win)
 
-  if config.ui.position ~= 'current' then
+  if windows.position ~= 'current' then
     window_options.set_window_option('winfixbuf', true, windows.output_win, { save_original = true })
   end
   window_options.set_window_option('winfixheight', true, windows.output_win, { save_original = true })
@@ -305,7 +305,7 @@ end
 
 ---@param windows OpencodeWindowState?
 function M.update_dimensions(windows)
-  if config.ui.position == 'current' then
+  if windows and windows.position == 'current' then
     return
   end
 
@@ -313,7 +313,7 @@ function M.update_dimensions(windows)
     return
   end
 
-  if config.ui.position == 'float' then
+  if windows.position == 'float' then
     float_layout.update(windows, windows.input_win ~= nil and vim.api.nvim_win_is_valid(windows.input_win))
     return
   end

--- a/lua/opencode/ui/ui.lua
+++ b/lua/opencode/ui/ui.lua
@@ -76,7 +76,7 @@ local function capture_hidden_snapshot(windows)
     output_cursor = cursor_positions.output,
     output_view = ok and type(view) == 'table' and view or nil,
     focused_window = focused,
-    position = config.ui.position,
+    position = windows.position,
     owner_tab = state.ui.are_windows_in_current_tab() and vim.api.nvim_get_current_tabpage() or nil,
   }
 end
@@ -115,7 +115,7 @@ local function close_or_restore_output_window(windows)
 
   output_window.restore_winfix_options(windows.output_win)
 
-  if config.ui.position == 'current' then
+  if windows.position == 'current' then
     if state.current_code_buf and vim.api.nvim_buf_is_valid(state.current_code_buf) then
       pcall(vim.api.nvim_win_set_buf, windows.output_win, state.current_code_buf)
     end
@@ -143,7 +143,7 @@ function M.hide_visible_windows(windows)
   local snapshot = capture_hidden_snapshot(windows)
 
   -- Only save width ratio for split modes (not dialog/current mode)
-  if config.ui.position ~= 'current' then
+  if windows.position ~= 'current' then
     local total_cols = vim.o.columns
     local current_width = vim.api.nvim_win_get_width(windows.output_win)
     state.ui.set_last_window_width_ratio(current_width / total_cols)
@@ -225,21 +225,22 @@ function M.restore_hidden_windows()
     footer_buf = footer.create_buf()
   end
 
-  local win_ids = M.create_split_windows(hidden.input_buf, hidden.output_buf)
-
-  state.ui.consume_hidden_buffers()
-
-  state.ui.set_windows({
+  local windows = {
     input_buf = hidden.input_buf,
     output_buf = hidden.output_buf,
     footer_buf = footer_buf,
-    input_win = win_ids.input_win,
-    output_win = win_ids.output_win,
-    footer_win = nil,
-    output_was_at_bottom = hidden.output_was_at_bottom == true,
-    saved_width_ratio = state.last_window_width_ratio,
-  })
-  local windows = state.windows
+    position = config.ui.position,
+  }
+  local win_ids = M.create_split_windows(windows)
+
+  state.ui.consume_hidden_buffers()
+
+  windows.input_win = win_ids.input_win
+  windows.output_win = win_ids.output_win
+  windows.footer_win = nil
+  windows.output_was_at_bottom = hidden.output_was_at_bottom == true
+  windows.saved_width_ratio = state.last_window_width_ratio
+  state.ui.set_windows(windows)
 
   state.ui.set_cursor_position('input', hidden.input_cursor)
   state.ui.set_cursor_position('output', hidden.output_cursor)
@@ -318,48 +319,43 @@ local function open_split(direction, type)
   return vim.api.nvim_get_current_win()
 end
 
----@param input_buf integer
----@param output_buf integer
+---@param windows OpencodeWindowState
 ---@return { input_win: integer, output_win: integer }
-local function open_float(input_buf, output_buf)
-  local output_config, input_config =
-    float_layout.window_configs({ input_buf = input_buf, output_buf = output_buf }, true)
-  local output_win = float_layout.open_win(output_buf, true, output_config)
-  local input_win = float_layout.open_win(input_buf, true, input_config)
+local function open_float(windows)
+  local output_config, input_config = float_layout.window_configs(windows, true)
+  local output_win = float_layout.open_win(windows.output_buf, true, output_config)
+  local input_win = float_layout.open_win(windows.input_buf, true, input_config)
 
   return { input_win = input_win, output_win = output_win }
 end
 
----@param input_buf integer
----@param output_buf integer
+---@param windows OpencodeWindowState
 ---@return { input_win: integer, output_win: integer }
-function M.create_split_windows(input_buf, output_buf)
+function M.create_split_windows(windows)
   if input_window.mounted() or output_window.mounted() then
     M.close_windows(state.windows, false)
   end
-  local ui_conf = config.ui
-
-  if ui_conf.position == 'float' then
-    return open_float(input_buf, output_buf)
+  if windows.position == 'float' then
+    return open_float(windows)
   end
 
   local main_win
-  if ui_conf.position == 'current' then
+  if windows.position == 'current' then
     main_win = vim.api.nvim_get_current_win()
   else
-    main_win = open_split(ui_conf.position, 'vertical')
+    main_win = open_split(windows.position, 'vertical')
   end
   vim.api.nvim_set_current_win(main_win)
 
-  local input_win = open_split(ui_conf.input_position, 'horizontal')
+  local input_win = open_split(config.ui.input_position, 'horizontal')
   local output_win = main_win
 
-  if ui_conf.position == 'current' then
+  if windows.position == 'current' then
     pcall(vim.api.nvim_set_option_value, 'winfixbuf', false, { win = output_win })
   end
 
-  vim.api.nvim_win_set_buf(input_win, input_buf)
-  vim.api.nvim_win_set_buf(output_win, output_buf)
+  vim.api.nvim_win_set_buf(input_win, windows.input_buf)
+  vim.api.nvim_win_set_buf(output_win, windows.output_buf)
   return { input_win = input_win, output_win = output_win }
 end
 
@@ -383,16 +379,16 @@ function M.create_windows()
   end
 
   -- Create new windows from scratch
-  local buffers = M.setup_buffers()
-  local windows = buffers
-  local win_ids = M.create_split_windows(buffers.input_buf, buffers.output_buf)
+  local windows = M.setup_buffers()
+  windows.position = config.ui.position
+  local win_ids = M.create_split_windows(windows)
 
   windows.input_win = win_ids.input_win
   windows.output_win = win_ids.output_win
 
   local filetype = config.ui.output.filetype or 'opencode_output'
   vim.api.nvim_win_call(windows.output_win, function()
-    vim.api.nvim_set_option_value('filetype', filetype, { buf = buffers.output_buf })
+    vim.api.nvim_set_option_value('filetype', filetype, { buf = windows.output_buf })
   end)
 
   windows.saved_width_ratio = state.last_window_width_ratio

--- a/tests/unit/navigation_spec.lua
+++ b/tests/unit/navigation_spec.lua
@@ -39,7 +39,7 @@ describe('output token navigation', function()
       col = 0,
     })
 
-    state.ui.set_windows({ output_buf = output_buf, output_win = output_win })
+    state.ui.set_windows({ output_buf = output_buf, output_win = output_win, position = 'right' })
     state.ui.set_last_code_window(code_win)
   end)
 
@@ -518,6 +518,7 @@ describe('output token navigation', function()
       input_win = input_win,
       output_buf = output_buf,
       output_win = code_win,
+      position = 'current',
     })
     state.ui.set_last_code_window(code_win)
     state.ui.set_current_code_buf(code_buf)
@@ -570,7 +571,7 @@ describe('navigation jumplist preservation', function()
       col = 0,
     })
 
-    state.ui.set_windows({ output_buf = output_buf, output_win = output_win })
+    state.ui.set_windows({ output_buf = output_buf, output_win = output_win, position = 'right' })
     state.ui.set_last_code_window(code_win)
   end)
 
@@ -673,7 +674,7 @@ describe('navigation hidden-messages-notice handling', function()
       row = 0,
       col = 0,
     })
-    state.ui.set_windows({ output_buf = output_buf, output_win = output_win })
+    state.ui.set_windows({ output_buf = output_buf, output_win = output_win, position = 'right' })
   end)
 
   after_each(function()

--- a/tests/unit/persist_state_spec.lua
+++ b/tests/unit/persist_state_spec.lua
@@ -270,6 +270,61 @@ describe('persist_state', function()
   end)
 
   describe('hidden buffer lifecycle', function()
+    it('restores the code buffer when a current window closes after position changes', function()
+      setup_ui({ position = 'current' })
+      create_code_file()
+
+      windows = ui.create_windows()
+      state.ui.set_windows(windows)
+      config.values.ui.position = 'right'
+
+      ui.teardown_visible_windows(windows)
+
+      assert.is_true(vim.api.nvim_win_is_valid(code_win))
+      assert.equals(code_buf, vim.api.nvim_win_get_buf(code_win))
+    end)
+
+    it('records the mounted window position in a hidden snapshot', function()
+      setup_ui({ position = 'current' })
+      create_code_file()
+
+      windows = ui.create_windows()
+      state.ui.set_windows(windows)
+      config.values.ui.position = 'right'
+
+      ui.hide_visible_windows(windows)
+
+      local hidden = state.ui.inspect_hidden_buffers()
+      assert.equals('current', hidden.position)
+    end)
+
+    it('reports the hidden snapshot position after the next config position changes', function()
+      setup_ui({ position = 'current' })
+      create_code_file()
+
+      windows = ui.create_windows()
+      state.ui.set_windows(windows)
+      ui.hide_visible_windows(windows)
+      config.values.ui.position = 'right'
+
+      local window_state = api.get_window_state()
+      assert.equals('hidden', window_state.status)
+      assert.equals('current', window_state.position)
+    end)
+
+    it('uses the current config position when restoring hidden buffers into new windows', function()
+      setup_ui({ position = 'current' })
+      create_code_file()
+
+      windows = ui.create_windows()
+      state.ui.set_windows(windows)
+      config.values.ui.position = 'right'
+      ui.hide_visible_windows(windows)
+
+      assert.is_true(ui.restore_hidden_windows())
+      assert.equals('right', state.windows.position)
+    end)
+
     it('preserves and restores buffers/content, including footer', function()
       setup_ui()
       create_code_file()

--- a/tests/unit/zoom_spec.lua
+++ b/tests/unit/zoom_spec.lua
@@ -42,6 +42,7 @@ describe('ui zoom state', function()
       input_win = input_win,
       output_buf = output_buf,
       output_win = output_win,
+      position = 'right',
     }
     state.ui.set_windows(windows)
     state.ui.set_pre_zoom_width(nil)
@@ -341,14 +342,11 @@ describe('ui zoom state', function()
     end)
 
     it('does not save width in dialog mode (position=current)', function()
-      local original_position = config.ui.position
-      config.ui.position = 'current'
+      windows.position = 'current'
       state.ui.clear_last_window_width_ratio()
 
       ui.hide_visible_windows(windows)
       assert.is_nil(state.last_window_width_ratio)
-
-      config.ui.position = original_position
     end)
 
     it('uses saved width ratio in output_window.update_dimensions', function()


### PR DESCRIPTION
## Summary

```text
Layout position
├── config.ui.position    -> where the next windows should open
└── windows.position      -> where the mounted windows actually opened
    ├── close/hide uses the mounted position
    └── restore/new windows use the current config
```

This prevents a `current` layout from closing its code window when configuration changes to `right` before teardown finishes.

- Sequence both toggles in the three-state layout recipe before changing position.
- Preserve mounted position through navigation, sizing, hiding, and teardown.
- Add regression coverage for current-to-right transitions and hidden restoration.

## Verification

- `./run_tests.sh -t tests/unit/persist_state_spec.lua`
- `./run_tests.sh -t tests/unit/navigation_spec.lua`
- `./run_tests.sh -t tests/unit/zoom_spec.lua`
- `./run_tests.sh`