### PR TITLE
[feat]: Add contextual actions to user messages

### DIFF
--- a/lua/opencode/api.lua
+++ b/lua/opencode/api.lua
@@ -52,6 +52,7 @@ local action_groups = {
     open_input_new_session_with_title = session.open_input_new_session_with_title,
     rename_session = session.rename_session,
     undo = session.undo,
+    copy_message = session.copy_message,
     fork_session = session.fork_session,
     toggle_session_lock = session.toggle_session_lock,
   },

--- a/lua/opencode/commands/handlers/session.lua
+++ b/lua/opencode/commands/handlers/session.lua
@@ -470,6 +470,36 @@ function M.actions.undo(message_id)
   end)
 end
 
+---@param message_id string
+function M.actions.copy_message(message_id)
+  return with_active_session('No active session to copy', function(state_obj)
+    local target = find_message_in_state(state_obj, message_id)
+    if not target or not target.info or target.info.role ~= 'user' then
+      vim.notify('No user message to copy', vim.log.levels.WARN)
+      return
+    end
+
+    local text_parts = {}
+    for _, part in ipairs(target.parts or {}) do
+      if
+        part.type == 'text'
+        and part.synthetic ~= true
+        and type(part.text) == 'string'
+        and vim.trim(part.text) ~= ''
+      then
+        text_parts[#text_parts + 1] = part.text
+      end
+    end
+
+    if #text_parts == 0 then
+      vim.notify('No message text to copy', vim.log.levels.WARN)
+      return
+    end
+
+    vim.fn.setreg('+', table.concat(text_parts, '\n\n'))
+  end)
+end
+
 ---@param state_obj OpencodeState
 ---@return string|nil
 local function find_next_message_for_redo(state_obj)

--- a/lua/opencode/types.lua
+++ b/lua/opencode/types.lua
@@ -543,7 +543,7 @@
 
 ---@class OutputAction
 ---@field text string Action text
----@field type 'diff_revert_all'|'diff_revert_selected_file'|'diff_open'|'diff_restore_snapshot_file'|'diff_restore_snapshot_all'|'navigate_session_tree'|'toggle_max_messages'
+---@field type 'diff_revert_all'|'diff_revert_selected_file'|'diff_open'|'diff_restore_snapshot_file'|'diff_restore_snapshot_all'|'navigate_session_tree'|'toggle_max_messages'|'undo'|'copy_message'|'fork_session'
 ---@field args? string[] Optional arguments for the command
 ---@field key string keybinding for the action
 ---@field display_line number Line number to display the action

--- a/lua/opencode/ui/contextual_actions.lua
+++ b/lua/opencode/ui/contextual_actions.lua
@@ -5,7 +5,6 @@ local M = {}
 local namespace = vim.api.nvim_create_namespace('opencode_contextual_actions')
 local augroup = vim.api.nvim_create_augroup('OpenCodeContextualActions', { clear = true })
 local lifecycles = {}
-local refresh_contextual_actions
 
 local function buffer_mapping(buf, key)
   for _, mapping in ipairs(vim.api.nvim_buf_get_keymap(buf, 'n')) do
@@ -31,79 +30,60 @@ local function restore_mapping(buf, mapping)
   vim.api.nvim_buf_set_keymap(buf, 'n', mapping.lhs, mapping.callback and '' or mapping.rhs, options)
 end
 
-local function lifecycle_for(buf)
-  if not lifecycles[buf] then
-    lifecycles[buf] = {
-      saved_mappings = {},
-      generation = 0,
-      observing = false,
-      actions = nil,
-    }
-  end
-  return lifecycles[buf]
-end
-
-local function invalidate(buf, lifecycle)
-  if lifecycles[buf] ~= lifecycle then
+local function clear_contextual_actions(buf)
+  local lifecycle = lifecycles[buf]
+  if not lifecycle then
     return
   end
 
-  lifecycle.generation = lifecycle.generation + 1
-  if not vim.api.nvim_buf_is_valid(buf) then
-    return
-  end
-
-  vim.api.nvim_buf_clear_namespace(buf, namespace, 0, -1)
-  for key, snapshot in pairs(lifecycle.saved_mappings) do
-    vim.keymap.del('n', key, { buffer = buf })
-    if snapshot.mapping then
-      restore_mapping(buf, snapshot.mapping)
+  if vim.api.nvim_buf_is_valid(buf) then
+    vim.api.nvim_buf_clear_namespace(buf, namespace, 0, -1)
+    for key, mapping in pairs(lifecycle.saved_mappings) do
+      vim.keymap.del('n', key, { buffer = buf })
+      if mapping then
+        restore_mapping(buf, mapping)
+      end
     end
   end
   lifecycle.saved_mappings = {}
   lifecycle.actions = nil
 end
 
-function M.setup_contextual_actions(windows)
-  local buf = windows.output_buf
-  local lifecycle = lifecycle_for(buf)
-  if lifecycle.observing then
-    refresh_contextual_actions(buf)
-    return
+local function ensure_lifecycle(buf)
+  local lifecycle = lifecycles[buf]
+  if lifecycle then
+    return lifecycle
   end
 
+  lifecycle = { saved_mappings = {}, actions = nil }
   assert(vim.api.nvim_buf_attach(buf, false, {
     on_lines = function()
-      invalidate(buf, lifecycle)
+      clear_contextual_actions(buf)
     end,
     on_reload = function()
-      invalidate(buf, lifecycle)
+      clear_contextual_actions(buf)
     end,
     on_detach = function()
-      invalidate(buf, lifecycle)
-      if lifecycles[buf] == lifecycle then
-        lifecycles[buf] = nil
-      end
+      clear_contextual_actions(buf)
+      lifecycles[buf] = nil
     end,
   }))
-  lifecycle.observing = true
-  refresh_contextual_actions(buf)
+  lifecycles[buf] = lifecycle
+  return lifecycle
 end
 
 function M.show_contextual_actions_menu(buf, actions)
-  local lifecycle = lifecycle_for(buf)
-  if not actions or #actions == 0 then
-    if lifecycle.actions then
-      invalidate(buf, lifecycle)
-    end
-    return
-  end
+  local lifecycle = ensure_lifecycle(buf)
+  actions = actions and #actions > 0 and actions or nil
 
   if vim.deep_equal(lifecycle.actions, actions) then
     return
   end
 
-  invalidate(buf, lifecycle)
+  clear_contextual_actions(buf)
+  if not actions then
+    return
+  end
   lifecycle.actions = actions
 
   for _, action in ipairs(actions) do
@@ -112,18 +92,15 @@ function M.show_contextual_actions_menu(buf, actions)
       virt_text_pos = 'right_align',
       hl_mode = 'combine',
     })
-  end
 
-  for _, action in ipairs(actions) do
-    if action.key and not lifecycle.saved_mappings[action.key] then
-      lifecycle.saved_mappings[action.key] = { mapping = buffer_mapping(buf, action.key) }
-      local generation = lifecycle.generation
+    if action.key and lifecycle.saved_mappings[action.key] == nil then
+      lifecycle.saved_mappings[action.key] = buffer_mapping(buf, action.key) or false
       vim.keymap.set('n', action.key, function()
-        if lifecycles[buf] ~= lifecycle or lifecycle.generation ~= generation then
+        if lifecycles[buf] ~= lifecycle or not vim.tbl_contains(lifecycle.actions or {}, action) then
           return
         end
 
-        invalidate(buf, lifecycle)
+        clear_contextual_actions(buf)
         if action.type and action.args then
           require('opencode.api')[action.type](unpack(action.args))
         end
@@ -132,14 +109,14 @@ function M.show_contextual_actions_menu(buf, actions)
   end
 end
 
-refresh_contextual_actions = function(buf)
+local function refresh_contextual_actions(buf)
   local lifecycle = lifecycles[buf]
   if not lifecycle then
     return
   end
 
   if not state.windows or state.windows.output_buf ~= buf or vim.api.nvim_get_current_buf() ~= buf then
-    invalidate(buf, lifecycle)
+    clear_contextual_actions(buf)
     return
   end
 
@@ -147,14 +124,12 @@ refresh_contextual_actions = function(buf)
   M.show_contextual_actions_menu(buf, require('opencode.ui.renderer').get_actions_for_line(line))
 end
 
-vim.api.nvim_create_autocmd({ 'CursorHold', 'BufEnter', 'WinEnter' }, {
-  group = augroup,
-  callback = function(event)
-    refresh_contextual_actions(event.buf)
-  end,
-})
+function M.setup_contextual_actions(windows)
+  ensure_lifecycle(windows.output_buf)
+  refresh_contextual_actions(windows.output_buf)
+end
 
-vim.api.nvim_create_autocmd('CursorMoved', {
+vim.api.nvim_create_autocmd({ 'CursorHold', 'CursorMoved', 'BufEnter', 'WinEnter' }, {
   group = augroup,
   callback = function(event)
     refresh_contextual_actions(event.buf)
@@ -164,10 +139,7 @@ vim.api.nvim_create_autocmd('CursorMoved', {
 vim.api.nvim_create_autocmd({ 'BufLeave', 'BufDelete', 'BufHidden' }, {
   group = augroup,
   callback = function(event)
-    local lifecycle = lifecycles[event.buf]
-    if lifecycle then
-      invalidate(event.buf, lifecycle)
-    end
+    clear_contextual_actions(event.buf)
   end,
 })
 

--- a/lua/opencode/ui/contextual_actions.lua
+++ b/lua/opencode/ui/contextual_actions.lua
@@ -1,110 +1,174 @@
 local state = require('opencode.state')
-local output_window = require('opencode.ui.output_window')
 
 local M = {}
 
--- Module state
-local last_line_num = nil
-local dirty = false
-local current_keymaps = {}
+local namespace = vim.api.nvim_create_namespace('opencode_contextual_actions')
+local augroup = vim.api.nvim_create_augroup('OpenCodeContextualActions', { clear = true })
+local lifecycles = {}
+local refresh_contextual_actions
 
-local function clear_keymaps(buf)
-  for key, _ in pairs(current_keymaps) do
-    vim.keymap.del('n', key, { buffer = buf })
+local function buffer_mapping(buf, key)
+  for _, mapping in ipairs(vim.api.nvim_buf_get_keymap(buf, 'n')) do
+    if mapping.lhs == key then
+      return mapping
+    end
   end
-  current_keymaps = {}
+end
+
+local function restore_mapping(buf, mapping)
+  local options = {
+    desc = mapping.desc,
+    silent = mapping.silent == 1,
+    expr = mapping.expr == 1,
+    nowait = mapping.nowait == 1,
+    noremap = mapping.noremap ~= 0,
+    script = mapping.script == 1,
+    replace_keycodes = mapping.replace_keycodes == 1,
+  }
+  if mapping.callback then
+    options.callback = mapping.callback
+  end
+  vim.api.nvim_buf_set_keymap(buf, 'n', mapping.lhs, mapping.callback and '' or mapping.rhs, options)
+end
+
+local function lifecycle_for(buf)
+  if not lifecycles[buf] then
+    lifecycles[buf] = {
+      saved_mappings = {},
+      generation = 0,
+      observing = false,
+      actions = nil,
+    }
+  end
+  return lifecycles[buf]
+end
+
+local function invalidate(buf, lifecycle)
+  if lifecycles[buf] ~= lifecycle then
+    return
+  end
+
+  lifecycle.generation = lifecycle.generation + 1
+  if not vim.api.nvim_buf_is_valid(buf) then
+    return
+  end
+
+  vim.api.nvim_buf_clear_namespace(buf, namespace, 0, -1)
+  for key, snapshot in pairs(lifecycle.saved_mappings) do
+    vim.keymap.del('n', key, { buffer = buf })
+    if snapshot.mapping then
+      restore_mapping(buf, snapshot.mapping)
+    end
+  end
+  lifecycle.saved_mappings = {}
+  lifecycle.actions = nil
 end
 
 function M.setup_contextual_actions(windows)
-  local ns_id = vim.api.nvim_create_namespace('opencode_contextual_actions')
-  local augroup = vim.api.nvim_create_augroup('OpenCodeContextualActions', { clear = true })
+  local buf = windows.output_buf
+  local lifecycle = lifecycle_for(buf)
+  if lifecycle.observing then
+    refresh_contextual_actions(buf)
+    return
+  end
 
-  vim.api.nvim_create_autocmd('CursorHold', {
-    group = augroup,
-    buffer = windows.output_buf,
-    callback = function()
-      vim.schedule(function()
-        local line_num = vim.api.nvim_win_get_cursor(0)[1]
-
-        if not line_num or line_num <= 0 or not state.windows or not state.windows.output_buf then
-          return
-        end
-
-        line_num = line_num - 1 -- need api-indexing (e.g. 0 based line #), win_get_cursor returns 1 based line #
-
-        local actions = require('opencode.ui.renderer').get_actions_for_line(line_num)
-        last_line_num = line_num
-
-        vim.api.nvim_buf_clear_namespace(state.windows.output_buf, ns_id, 0, -1)
-        clear_keymaps(state.windows.output_buf)
-
-        if actions and #actions > 0 then
-          dirty = true
-          M.show_contextual_actions_menu(state.windows.output_buf, actions, ns_id)
-        end
-      end)
+  assert(vim.api.nvim_buf_attach(buf, false, {
+    on_lines = function()
+      invalidate(buf, lifecycle)
     end,
-  })
-
-  vim.api.nvim_create_autocmd('CursorMoved', {
-    group = augroup,
-    buffer = windows.output_buf,
-    callback = function()
-      vim.schedule(function()
-        if not output_window.mounted() then
-          return
-        end
-        ---@cast state.windows { output_buf: integer}
-        local line_num = vim.api.nvim_win_get_cursor(0)[1]
-        if last_line_num == line_num and not dirty then
-          return
-        end
-        vim.api.nvim_buf_clear_namespace(state.windows.output_buf, ns_id, 0, -1)
-      end)
+    on_reload = function()
+      invalidate(buf, lifecycle)
     end,
-  })
-
-  vim.api.nvim_create_autocmd({ 'BufLeave', 'BufDelete', 'BufHidden' }, {
-    group = augroup,
-    buffer = windows.output_buf,
-    callback = function()
-      if state.windows and state.windows.output_buf then
-        vim.api.nvim_buf_clear_namespace(state.windows.output_buf, ns_id, 0, -1)
-        clear_keymaps(state.windows.output_buf)
+    on_detach = function()
+      invalidate(buf, lifecycle)
+      if lifecycles[buf] == lifecycle then
+        lifecycles[buf] = nil
       end
-      last_line_num = nil
-      dirty = false
     end,
-  })
+  }))
+  lifecycle.observing = true
+  refresh_contextual_actions(buf)
 end
 
-function M.show_contextual_actions_menu(buf, actions, ns_id)
-  clear_keymaps(buf)
+function M.show_contextual_actions_menu(buf, actions)
+  local lifecycle = lifecycle_for(buf)
+  if not actions or #actions == 0 then
+    if lifecycle.actions then
+      invalidate(buf, lifecycle)
+    end
+    return
+  end
+
+  if vim.deep_equal(lifecycle.actions, actions) then
+    return
+  end
+
+  invalidate(buf, lifecycle)
+  lifecycle.actions = actions
 
   for _, action in ipairs(actions) do
-    ---@type OutputExtmark
-    local mark = {
+    vim.api.nvim_buf_set_extmark(buf, namespace, action.display_line, 0, {
       virt_text = { { '⋮ ' .. action.text .. ' ', 'OpencodeContextualActions' } },
       virt_text_pos = 'right_align',
       hl_mode = 'combine',
-    }
-
-    vim.api.nvim_buf_set_extmark(buf, ns_id, action.display_line, 0, mark --[[@as vim.api.keyset.set_extmark]])
+    })
   end
-  -- Setup key mappings for actions
+
   for _, action in ipairs(actions) do
-    if action.key then
-      current_keymaps[action.key] = true
+    if action.key and not lifecycle.saved_mappings[action.key] then
+      lifecycle.saved_mappings[action.key] = { mapping = buffer_mapping(buf, action.key) }
+      local generation = lifecycle.generation
       vim.keymap.set('n', action.key, function()
+        if lifecycles[buf] ~= lifecycle or lifecycle.generation ~= generation then
+          return
+        end
+
+        invalidate(buf, lifecycle)
         if action.type and action.args then
-          vim.api.nvim_buf_clear_namespace(buf, ns_id, 0, -1)
-          clear_keymaps(buf)
-          local api = require('opencode.api')
-          api[action.type](unpack(action.args))
+          require('opencode.api')[action.type](unpack(action.args))
         end
       end, { buffer = buf, silent = true, desc = action.text })
     end
   end
 end
+
+refresh_contextual_actions = function(buf)
+  local lifecycle = lifecycles[buf]
+  if not lifecycle then
+    return
+  end
+
+  if not state.windows or state.windows.output_buf ~= buf or vim.api.nvim_get_current_buf() ~= buf then
+    invalidate(buf, lifecycle)
+    return
+  end
+
+  local line = vim.api.nvim_win_get_cursor(0)[1] - 1
+  M.show_contextual_actions_menu(buf, require('opencode.ui.renderer').get_actions_for_line(line))
+end
+
+vim.api.nvim_create_autocmd({ 'CursorHold', 'BufEnter', 'WinEnter' }, {
+  group = augroup,
+  callback = function(event)
+    refresh_contextual_actions(event.buf)
+  end,
+})
+
+vim.api.nvim_create_autocmd('CursorMoved', {
+  group = augroup,
+  callback = function(event)
+    refresh_contextual_actions(event.buf)
+  end,
+})
+
+vim.api.nvim_create_autocmd({ 'BufLeave', 'BufDelete', 'BufHidden' }, {
+  group = augroup,
+  callback = function(event)
+    local lifecycle = lifecycles[event.buf]
+    if lifecycle then
+      invalidate(event.buf, lifecycle)
+    end
+  end,
+})
 
 return M

--- a/lua/opencode/ui/formatter.lua
+++ b/lua/opencode/ui/formatter.lua
@@ -1012,7 +1012,7 @@ function M.format_part(part, message, is_last_part, context)
     if is_compaction_part(part) then
       format_compaction_divider(output)
       content_added = true
-    elseif part.type == 'text' and part.text then
+    elseif part.type == 'text' and type(part.text) == 'string' then
       if part.synthetic == true then
         part._message_context = message
         M._format_selection_context(output, part)

--- a/lua/opencode/ui/render_state.lua
+++ b/lua/opencode/ui/render_state.lua
@@ -2,6 +2,7 @@
 ---@field message OpencodeMessage Direct reference to message in state.messages
 ---@field line_start integer? Line where message header starts
 ---@field line_end integer? Line where message header ends
+---@field actions OutputAction[] Actions associated with this message
 
 ---@class RenderedPart
 ---@field part OpencodeMessagePart Direct reference to part in state.messages
@@ -127,6 +128,22 @@ local function range_lookup(ranges, line)
     end
   end
   return nil
+end
+
+local function range_before_or_at(ranges, line)
+  local lo, hi = 1, #ranges
+  local result = nil
+  while lo <= hi do
+    local mid = math.floor((lo + hi) / 2)
+    local range = ranges[mid]
+    if range[1] <= line then
+      result = range[3]
+      lo = mid + 1
+    else
+      hi = mid - 1
+    end
+  end
+  return result
 end
 
 function RenderState:_rebuild_ranges()
@@ -345,18 +362,19 @@ end
 ---@return table[]
 function RenderState:get_actions_at_line(line)
   self:_ensure_ranges()
-  local part_id = range_lookup(self._part_ranges, line)
-  if not part_id then
-    return {}
-  end
-
-  local part_data = self._parts[part_id]
-  if not part_data or not part_data.actions then
-    return {}
-  end
-
   local actions = {}
-  for _, action in ipairs(part_data.actions) do
+
+  local message_id = range_before_or_at(self._message_ranges, line)
+  local message_data = message_id and self._messages[message_id]
+  for _, action in ipairs(message_data and message_data.actions or {}) do
+    if action.range and action.range.from <= line and action.range.to >= line then
+      actions[#actions + 1] = action
+    end
+  end
+
+  local part_id = range_lookup(self._part_ranges, line)
+  local part_data = part_id and self._parts[part_id]
+  for _, action in ipairs(part_data and part_data.actions or {}) do
     if action.range and action.range.from <= line and action.range.to >= line then
       actions[#actions + 1] = action
     end
@@ -478,6 +496,11 @@ end
 ---@return table[]
 function RenderState:get_all_actions()
   local all_actions = {}
+  for _, message_data in pairs(self._messages) do
+    for _, action in ipairs(message_data.actions or {}) do
+      all_actions[#all_actions + 1] = action
+    end
+  end
   for _, part_data in pairs(self._parts) do
     if part_data.actions then
       for _, action in ipairs(part_data.actions) do
@@ -486,6 +509,59 @@ function RenderState:get_all_actions()
     end
   end
   return all_actions
+end
+
+local function is_actionable_user_message(message)
+  local info = message and message.info
+  if not info or info.role ~= 'user' or type(info.id) ~= 'string' or info.id == '' then
+    return false
+  end
+
+  for _, part in ipairs(message.parts or {}) do
+    if part.type == 'text' and part.synthetic ~= true and type(part.text) == 'string' and vim.trim(part.text) ~= '' then
+      return true
+    end
+  end
+
+  return false
+end
+
+function RenderState:_refresh_message_actions(message_id)
+  local message_data = self._messages[message_id]
+  if not message_data or not message_data.line_start or not message_data.line_end then
+    return
+  end
+
+  if not is_actionable_user_message(message_data.message) then
+    message_data.actions = {}
+    return
+  end
+
+  local line_end = message_data.line_end
+  for _, part in ipairs(message_data.message.parts or {}) do
+    local part_data = part.id and self._parts[part.id]
+    if part_data and part_data.line_end then
+      line_end = math.max(line_end, part_data.line_end)
+    end
+  end
+
+  local id = message_data.message.info.id
+  local function action(text, action_type, key)
+    return {
+      text = text,
+      type = action_type,
+      args = { id },
+      key = key,
+      display_line = line_end,
+      range = { from = message_data.line_start, to = line_end },
+    }
+  end
+
+  message_data.actions = {
+    action('[R]evert', 'undo', 'R'),
+    action('[C]opy', 'copy_message', 'C'),
+    action('[F]ork', 'fork_session', 'F'),
+  }
 end
 
 ---@param targets RenderedTarget[]
@@ -511,6 +587,7 @@ function RenderState:set_message(message, line_start, line_end)
       message = message,
       line_start = line_start,
       line_end = line_end,
+      actions = {},
     }
   else
     existing.message = message
@@ -528,6 +605,7 @@ function RenderState:set_message(message, line_start, line_end)
       self._max_line_end = line_end
     end
   end
+  self:_refresh_message_actions(message_id)
 end
 
 ---@param part OpencodeMessagePart
@@ -579,6 +657,7 @@ function RenderState:set_part(part, line_start, line_end)
   end
 
   self:_index_task_part_child_session(part_id, part)
+  self:_refresh_message_actions(message_id)
 end
 
 ---@param part_id string
@@ -620,6 +699,8 @@ function RenderState:update_part_lines(part_id, new_line_start, new_line_end)
     self:shift_all(old_line_end + 1, delta)
   end
 
+  self:_refresh_message_actions(part_data.message_id)
+
   return true
 end
 
@@ -640,6 +721,7 @@ function RenderState:update_part_data(part_ref)
   end
 
   self:_index_task_part_child_session(part_ref.id, part_ref)
+  self:_refresh_message_actions(rendered_part.message_id)
   return rendered_part
 end
 
@@ -659,6 +741,7 @@ function RenderState:remove_part(part_id)
 
   if not part_data.line_start or not part_data.line_end then
     self._parts[part_id] = nil
+    self:_refresh_message_actions(part_data.message_id)
     return true
   end
 
@@ -672,6 +755,7 @@ function RenderState:remove_part(part_id)
   end
 
   self:shift_all(shift_from, -line_count)
+  self:_refresh_message_actions(part_data.message_id)
   return true
 end
 
@@ -740,6 +824,7 @@ function RenderState:shift_all(from_line, delta)
   self:_rebuild_ranges()
 
   local shifted = false
+  local action_messages = {}
 
   local msg_ranges = self._message_ranges
   local first_msg = first_range_at_or_after(msg_ranges, from_line)
@@ -749,6 +834,9 @@ function RenderState:shift_all(from_line, delta)
       msg_data.line_start = msg_data.line_start + delta
       msg_data.line_end = msg_data.line_end + delta
       shifted = true
+      for _, action in ipairs(msg_data.actions or {}) do
+        shift_action(action, delta)
+      end
     end
   end
 
@@ -760,6 +848,7 @@ function RenderState:shift_all(from_line, delta)
       part_data.line_start = part_data.line_start + delta
       part_data.line_end = part_data.line_end + delta
       shifted = true
+      action_messages[part_data.message_id] = true
       for _, action in ipairs(part_data.actions) do
         shift_action(action, delta)
       end
@@ -772,6 +861,10 @@ function RenderState:shift_all(from_line, delta)
     if self._max_line_end_valid then
       self._max_line_end = self._max_line_end + delta
     end
+  end
+
+  for message_id in pairs(action_messages) do
+    self:_refresh_message_actions(message_id)
   end
 end
 

--- a/tests/data/api-abort.expected.json
+++ b/tests/data/api-abort.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_a27d8299d001nchmBunYlZcPyL"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_a27d8299d001nchmBunYlZcPyL"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_a27d8299d001nchmBunYlZcPyL"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/api-error.expected.json
+++ b/tests/data/api-error.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_9ffef0129001CoCrBKemk7DqcU"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_9ffef0129001CoCrBKemk7DqcU"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_9ffef0129001CoCrBKemk7DqcU"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/compaction-after-messages.expected.json
+++ b/tests/data/compaction-after-messages.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_after_user"
+      ],
+      "display_line": 8,
+      "key": "R",
+      "range": {
+        "from": 4,
+        "to": 8
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_after_user"
+      ],
+      "display_line": 8,
+      "key": "C",
+      "range": {
+        "from": 4,
+        "to": 8
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_after_user"
+      ],
+      "display_line": 8,
+      "key": "F",
+      "range": {
+        "from": 4,
+        "to": 8
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/cursor_data.expected.json
+++ b/tests/data/cursor_data.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_a3637244a001FDRDfoBYVPEGpd"
+      ],
+      "display_line": 11,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 11
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_a3637244a001FDRDfoBYVPEGpd"
+      ],
+      "display_line": 11,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 11
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_a3637244a001FDRDfoBYVPEGpd"
+      ],
+      "display_line": 11,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 11
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/diagnostics.expected.json
+++ b/tests/data/diagnostics.expected.json
@@ -2,78 +2,117 @@
   "actions": [
     {
       "args": [
-        "8e7903714919009004aad8754db0035fb47ecb24"
+        "msg_a49ed91d6001coTsjFq9x6FF5W"
       ],
-      "display_line": 57,
+      "display_line": 8,
       "key": "R",
       "range": {
-        "from": 57,
-        "to": 57
+        "from": 0,
+        "to": 8
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_a49ed91d6001coTsjFq9x6FF5W"
+      ],
+      "display_line": 8,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 8
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_a49ed91d6001coTsjFq9x6FF5W"
+      ],
+      "display_line": 8,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 8
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
+        "f33f38a70b284207e092c2c578a24e96fdd1bd4d"
+      ],
+      "display_line": 94,
+      "key": "R",
+      "range": {
+        "from": 94,
+        "to": 94
       },
       "text": "[R]evert file",
       "type": "diff_revert_selected_file"
     },
     {
       "args": [
-        "8e7903714919009004aad8754db0035fb47ecb24"
+        "f33f38a70b284207e092c2c578a24e96fdd1bd4d"
       ],
-      "display_line": 57,
+      "display_line": 94,
       "key": "A",
       "range": {
-        "from": 57,
-        "to": 57
+        "from": 94,
+        "to": 94
       },
       "text": "Revert [A]ll",
       "type": "diff_revert_all"
     },
     {
       "args": [
-        "8e7903714919009004aad8754db0035fb47ecb24"
+        "f33f38a70b284207e092c2c578a24e96fdd1bd4d"
       ],
-      "display_line": 57,
+      "display_line": 94,
       "key": "D",
       "range": {
-        "from": 57,
-        "to": 57
+        "from": 94,
+        "to": 94
       },
       "text": "[D]iff",
       "type": "diff_open"
     },
     {
       "args": [
-        "f33f38a70b284207e092c2c578a24e96fdd1bd4d"
+        "8e7903714919009004aad8754db0035fb47ecb24"
       ],
-      "display_line": 94,
+      "display_line": 57,
       "key": "R",
       "range": {
-        "from": 94,
-        "to": 94
+        "from": 57,
+        "to": 57
       },
       "text": "[R]evert file",
       "type": "diff_revert_selected_file"
     },
     {
       "args": [
-        "f33f38a70b284207e092c2c578a24e96fdd1bd4d"
+        "8e7903714919009004aad8754db0035fb47ecb24"
       ],
-      "display_line": 94,
+      "display_line": 57,
       "key": "A",
       "range": {
-        "from": 94,
-        "to": 94
+        "from": 57,
+        "to": 57
       },
       "text": "Revert [A]ll",
       "type": "diff_revert_all"
     },
     {
       "args": [
-        "f33f38a70b284207e092c2c578a24e96fdd1bd4d"
+        "8e7903714919009004aad8754db0035fb47ecb24"
       ],
-      "display_line": 94,
+      "display_line": 57,
       "key": "D",
       "range": {
-        "from": 94,
-        "to": 94
+        "from": 57,
+        "to": 57
       },
       "text": "[D]iff",
       "type": "diff_open"

--- a/tests/data/diff.expected.json
+++ b/tests/data/diff.expected.json
@@ -2,6 +2,45 @@
   "actions": [
     {
       "args": [
+        "msg_9d7287269001C5gRusYfX7A1w1"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_9d7287269001C5gRusYfX7A1w1"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_9d7287269001C5gRusYfX7A1w1"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
         "1f593f7ed419c95d3995f8ef4b98d4e571c3a492"
       ],
       "display_line": 18,

--- a/tests/data/explore.expected.json
+++ b/tests/data/explore.expected.json
@@ -2,6 +2,45 @@
   "actions": [
     {
       "args": [
+        "msg_cbe0c07af001FqFiaeygb5fC3O"
+      ],
+      "display_line": 4,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_cbe0c07af001FqFiaeygb5fC3O"
+      ],
+      "display_line": 4,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_cbe0c07af001FqFiaeygb5fC3O"
+      ],
+      "display_line": 4,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
         "ses_341f3e676ffez6WUF6zpok7dUZ"
       ],
       "display_line": 9,

--- a/tests/data/markdown-codefence.expected.json
+++ b/tests/data/markdown-codefence.expected.json
@@ -2,6 +2,45 @@
   "actions": [
     {
       "args": [
+        "msg_a2cf5ce65001YLvVsYxIboFcP4"
+      ],
+      "display_line": 36,
+      "key": "R",
+      "range": {
+        "from": 30,
+        "to": 36
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_a2cf5ce65001YLvVsYxIboFcP4"
+      ],
+      "display_line": 36,
+      "key": "C",
+      "range": {
+        "from": 30,
+        "to": 36
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_a2cf5ce65001YLvVsYxIboFcP4"
+      ],
+      "display_line": 36,
+      "key": "F",
+      "range": {
+        "from": 30,
+        "to": 36
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
         "c64ddee834f1b802020a8f880eafa689f0b99406"
       ],
       "display_line": 23,

--- a/tests/data/mcp-tool.expected.json
+++ b/tests/data/mcp-tool.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_mcp_user1"
+      ],
+      "display_line": 4,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_mcp_user1"
+      ],
+      "display_line": 4,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_mcp_user1"
+      ],
+      "display_line": 4,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/mentions-with-ranges.expected.json
+++ b/tests/data/mentions-with-ranges.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_9daca16bf0017x95VD45mw3k8Q"
+      ],
+      "display_line": 22,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 22
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_9daca16bf0017x95VD45mw3k8Q"
+      ],
+      "display_line": 22,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 22
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_9daca16bf0017x95VD45mw3k8Q"
+      ],
+      "display_line": 22,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 22
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/message-removal.expected.json
+++ b/tests/data/message-removal.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_001"
+      ],
+      "display_line": 10,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 10
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_001"
+      ],
+      "display_line": 10,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 10
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_001"
+      ],
+      "display_line": 10,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 10
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/multiple-messages-synthetic.expected.json
+++ b/tests/data/multiple-messages-synthetic.expected.json
@@ -1,5 +1,123 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_005"
+      ],
+      "display_line": 36,
+      "key": "R",
+      "range": {
+        "from": 32,
+        "to": 36
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_005"
+      ],
+      "display_line": 36,
+      "key": "C",
+      "range": {
+        "from": 32,
+        "to": 36
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_005"
+      ],
+      "display_line": 36,
+      "key": "F",
+      "range": {
+        "from": 32,
+        "to": 36
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
+        "msg_001"
+      ],
+      "display_line": 4,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_001"
+      ],
+      "display_line": 4,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_001"
+      ],
+      "display_line": 4,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
+        "msg_003"
+      ],
+      "display_line": 20,
+      "key": "R",
+      "range": {
+        "from": 16,
+        "to": 20
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_003"
+      ],
+      "display_line": 20,
+      "key": "C",
+      "range": {
+        "from": 16,
+        "to": 20
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_003"
+      ],
+      "display_line": 20,
+      "key": "F",
+      "range": {
+        "from": 16,
+        "to": 20
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/multiple-messages.expected.json
+++ b/tests/data/multiple-messages.expected.json
@@ -1,5 +1,84 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_a3d79a71f001dkQYw23QnYYElB"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_a3d79a71f001dkQYw23QnYYElB"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_a3d79a71f001dkQYw23QnYYElB"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
+        "msg_a3d79aa5b0014RYY4My2AeTokd"
+      ],
+      "display_line": 31,
+      "key": "R",
+      "range": {
+        "from": 25,
+        "to": 31
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_a3d79aa5b0014RYY4My2AeTokd"
+      ],
+      "display_line": 31,
+      "key": "C",
+      "range": {
+        "from": 25,
+        "to": 31
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_a3d79aa5b0014RYY4My2AeTokd"
+      ],
+      "display_line": 31,
+      "key": "F",
+      "range": {
+        "from": 25,
+        "to": 31
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/multiple-question-ask-reply-all.expected.json
+++ b/tests/data/multiple-question-ask-reply-all.expected.json
@@ -2,6 +2,45 @@
   "actions": [
     {
       "args": [
+        "msg_bfab6dbf3001ZOVHTFKR1CMUE5"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_bfab6dbf3001ZOVHTFKR1CMUE5"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_bfab6dbf3001ZOVHTFKR1CMUE5"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
         "be64b6205f0da4c9240df2476dc35495429161b5"
       ],
       "display_line": 23,

--- a/tests/data/multiple-question-ask.expected.json
+++ b/tests/data/multiple-question-ask.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_bfab6dbf3001ZOVHTFKR1CMUE5"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_bfab6dbf3001ZOVHTFKR1CMUE5"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_bfab6dbf3001ZOVHTFKR1CMUE5"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/part-before-message-delta.expected.json
+++ b/tests/data/part-before-message-delta.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_0000000000001"
+      ],
+      "display_line": 4,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_0000000000001"
+      ],
+      "display_line": 4,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_0000000000001"
+      ],
+      "display_line": 4,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/perf.expected.json
+++ b/tests/data/perf.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_a17b4dc4c001x19oFZANB8CsEB"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_a17b4dc4c001x19oFZANB8CsEB"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_a17b4dc4c001x19oFZANB8CsEB"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/permission-ask-new-approve.expected.json
+++ b/tests/data/permission-ask-new-approve.expected.json
@@ -2,6 +2,45 @@
   "actions": [
     {
       "args": [
+        "msg_b8e7c60a2001Kisjwk2mVB4dye"
+      ],
+      "display_line": 8,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 8
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_b8e7c60a2001Kisjwk2mVB4dye"
+      ],
+      "display_line": 8,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 8
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_b8e7c60a2001Kisjwk2mVB4dye"
+      ],
+      "display_line": 8,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 8
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
         "5ba6e95774829e7f501299039b72b72dc32c6620"
       ],
       "display_line": 36,

--- a/tests/data/permission-ask-new-deny.expected.json
+++ b/tests/data/permission-ask-new-deny.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_b8e7d8222001ZAc4G1t5RfHzou"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_b8e7d8222001ZAc4G1t5RfHzou"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_b8e7d8222001ZAc4G1t5RfHzou"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/permission-ask-new.expected.json
+++ b/tests/data/permission-ask-new.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_b8e7c60a2001Kisjwk2mVB4dye"
+      ],
+      "display_line": 8,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 8
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_b8e7c60a2001Kisjwk2mVB4dye"
+      ],
+      "display_line": 8,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 8
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_b8e7c60a2001Kisjwk2mVB4dye"
+      ],
+      "display_line": 8,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 8
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/permission.expected.json
+++ b/tests/data/permission.expected.json
@@ -2,6 +2,45 @@
   "actions": [
     {
       "args": [
+        "msg_9d6f253910015UFmkGkiWtUsRW"
+      ],
+      "display_line": 4,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_9d6f253910015UFmkGkiWtUsRW"
+      ],
+      "display_line": 4,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_9d6f253910015UFmkGkiWtUsRW"
+      ],
+      "display_line": 4,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
         "c78fb2dd2d533cfe530692cc3e3c8f92a0e4af1d"
       ],
       "display_line": 14,

--- a/tests/data/planning.expected.json
+++ b/tests/data/planning.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_9d45d40c9001s7A1sP3Ew537QN"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_9d45d40c9001s7A1sP3Ew537QN"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_9d45d40c9001s7A1sP3Ew537QN"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/provider-overloaded-status.expected.json
+++ b/tests/data/provider-overloaded-status.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_0000000000001"
+      ],
+      "display_line": 4,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_0000000000001"
+      ],
+      "display_line": 4,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_0000000000001"
+      ],
+      "display_line": 4,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/question-ask-other.expected.json
+++ b/tests/data/question-ask-other.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_c595d93bb001YP4s8b1oxCvGev"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_c595d93bb001YP4s8b1oxCvGev"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_c595d93bb001YP4s8b1oxCvGev"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/question-ask-replied.expected.json
+++ b/tests/data/question-ask-replied.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_bfaafef41001700DjtCwvhFxse"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_bfaafef41001700DjtCwvhFxse"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_bfaafef41001700DjtCwvhFxse"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/question-ask.expected.json
+++ b/tests/data/question-ask.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_bfaa078a2001RUYhlKZhSlyWeF"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_bfaa078a2001RUYhlKZhSlyWeF"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_bfaa078a2001RUYhlKZhSlyWeF"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/question-multiple-choices-answered.expected.json
+++ b/tests/data/question-multiple-choices-answered.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_f5cc36bf6001DoYmNlAd9dSCzU"
+      ],
+      "display_line": 4,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_f5cc36bf6001DoYmNlAd9dSCzU"
+      ],
+      "display_line": 4,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_f5cc36bf6001DoYmNlAd9dSCzU"
+      ],
+      "display_line": 4,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/question-multiple-choices.expected.json
+++ b/tests/data/question-multiple-choices.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_f5bf094d40010EarsFjD5WvW47"
+      ],
+      "display_line": 4,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_f5bf094d40010EarsFjD5WvW47"
+      ],
+      "display_line": 4,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_f5bf094d40010EarsFjD5WvW47"
+      ],
+      "display_line": 4,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/question-multiple-other.expected.json
+++ b/tests/data/question-multiple-other.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_f5ca5903d0014XOHFNqdkjZjV0"
+      ],
+      "display_line": 4,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_f5ca5903d0014XOHFNqdkjZjV0"
+      ],
+      "display_line": 4,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_f5ca5903d0014XOHFNqdkjZjV0"
+      ],
+      "display_line": 4,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/reasoning.expected.json
+++ b/tests/data/reasoning.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_reason_user1"
+      ],
+      "display_line": 4,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_reason_user1"
+      ],
+      "display_line": 4,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_reason_user1"
+      ],
+      "display_line": 4,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/redo-all.expected.json
+++ b/tests/data/redo-all.expected.json
@@ -2,42 +2,120 @@
   "actions": [
     {
       "args": [
-        "d988cc85565b99017d40ad8baea20225165be9d5"
+        "msg_a0236fd1c001TlwqL8fwvq529i"
       ],
-      "display_line": 90,
+      "display_line": 67,
       "key": "R",
       "range": {
-        "from": 90,
-        "to": 90
+        "from": 63,
+        "to": 67
       },
-      "text": "[R]evert file",
-      "type": "diff_revert_selected_file"
+      "text": "[R]evert",
+      "type": "undo"
     },
     {
       "args": [
-        "d988cc85565b99017d40ad8baea20225165be9d5"
+        "msg_a0236fd1c001TlwqL8fwvq529i"
       ],
-      "display_line": 90,
-      "key": "A",
+      "display_line": 67,
+      "key": "C",
       "range": {
-        "from": 90,
-        "to": 90
+        "from": 63,
+        "to": 67
       },
-      "text": "Revert [A]ll",
-      "type": "diff_revert_all"
+      "text": "[C]opy",
+      "type": "copy_message"
     },
     {
       "args": [
-        "d988cc85565b99017d40ad8baea20225165be9d5"
+        "msg_a0236fd1c001TlwqL8fwvq529i"
       ],
-      "display_line": 90,
-      "key": "D",
+      "display_line": 67,
+      "key": "F",
       "range": {
-        "from": 90,
-        "to": 90
+        "from": 63,
+        "to": 67
       },
-      "text": "[D]iff",
-      "type": "diff_open"
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
+        "msg_a0234e308001SKl5bQUibp5gtI"
+      ],
+      "display_line": 33,
+      "key": "R",
+      "range": {
+        "from": 29,
+        "to": 33
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_a0234e308001SKl5bQUibp5gtI"
+      ],
+      "display_line": 33,
+      "key": "C",
+      "range": {
+        "from": 29,
+        "to": 33
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_a0234e308001SKl5bQUibp5gtI"
+      ],
+      "display_line": 33,
+      "key": "F",
+      "range": {
+        "from": 29,
+        "to": 33
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
+        "msg_a0234c0b7001y2o9S1jMaNVZar"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_a0234c0b7001y2o9S1jMaNVZar"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_a0234c0b7001y2o9S1jMaNVZar"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
     },
     {
       "args": [
@@ -113,6 +191,45 @@
       "range": {
         "from": 56,
         "to": 56
+      },
+      "text": "[D]iff",
+      "type": "diff_open"
+    },
+    {
+      "args": [
+        "d988cc85565b99017d40ad8baea20225165be9d5"
+      ],
+      "display_line": 90,
+      "key": "R",
+      "range": {
+        "from": 90,
+        "to": 90
+      },
+      "text": "[R]evert file",
+      "type": "diff_revert_selected_file"
+    },
+    {
+      "args": [
+        "d988cc85565b99017d40ad8baea20225165be9d5"
+      ],
+      "display_line": 90,
+      "key": "A",
+      "range": {
+        "from": 90,
+        "to": 90
+      },
+      "text": "Revert [A]ll",
+      "type": "diff_revert_all"
+    },
+    {
+      "args": [
+        "d988cc85565b99017d40ad8baea20225165be9d5"
+      ],
+      "display_line": 90,
+      "key": "D",
+      "range": {
+        "from": 90,
+        "to": 90
       },
       "text": "[D]iff",
       "type": "diff_open"

--- a/tests/data/redo-once.expected.json
+++ b/tests/data/redo-once.expected.json
@@ -2,6 +2,84 @@
   "actions": [
     {
       "args": [
+        "msg_a0234c0b7001y2o9S1jMaNVZar"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_a0234c0b7001y2o9S1jMaNVZar"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_a0234c0b7001y2o9S1jMaNVZar"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
+        "msg_a0234e308001SKl5bQUibp5gtI"
+      ],
+      "display_line": 33,
+      "key": "R",
+      "range": {
+        "from": 29,
+        "to": 33
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_a0234e308001SKl5bQUibp5gtI"
+      ],
+      "display_line": 33,
+      "key": "C",
+      "range": {
+        "from": 29,
+        "to": 33
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_a0234e308001SKl5bQUibp5gtI"
+      ],
+      "display_line": 33,
+      "key": "F",
+      "range": {
+        "from": 29,
+        "to": 33
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
         "1b6ba655c6c0d899965adff278ac6320d5fc3b12"
       ],
       "display_line": 22,

--- a/tests/data/revert.expected.json
+++ b/tests/data/revert.expected.json
@@ -2,6 +2,84 @@
   "actions": [
     {
       "args": [
+        "msg_9fd985573001fk1Xlot7uyDgTo"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_9fd985573001fk1Xlot7uyDgTo"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_9fd985573001fk1Xlot7uyDgTo"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
+        "msg_9fd988c92001w0IZCVPQsN6xa9"
+      ],
+      "display_line": 29,
+      "key": "R",
+      "range": {
+        "from": 25,
+        "to": 29
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_9fd988c92001w0IZCVPQsN6xa9"
+      ],
+      "display_line": 29,
+      "key": "C",
+      "range": {
+        "from": 25,
+        "to": 29
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_9fd988c92001w0IZCVPQsN6xa9"
+      ],
+      "display_line": 29,
+      "key": "F",
+      "range": {
+        "from": 25,
+        "to": 29
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
         "c410b2b4024de020aea223c5248eec89216de53f"
       ],
       "display_line": 53,

--- a/tests/data/selection.expected.json
+++ b/tests/data/selection.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_9f5b29fea001z6jYXF7CG9omHa"
+      ],
+      "display_line": 14,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 14
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_9f5b29fea001z6jYXF7CG9omHa"
+      ],
+      "display_line": 14,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 14
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_9f5b29fea001z6jYXF7CG9omHa"
+      ],
+      "display_line": 14,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 14
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/shifting-and-multiple-perms.expected.json
+++ b/tests/data/shifting-and-multiple-perms.expected.json
@@ -1,5 +1,123 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_9efb39d68001J2h30a50B2774b"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_9efb39d68001J2h30a50B2774b"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_9efb39d68001J2h30a50B2774b"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
+        "msg_9efb50a0b001WFK7AMDV45cF8Z"
+      ],
+      "display_line": 86,
+      "key": "R",
+      "range": {
+        "from": 82,
+        "to": 86
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_9efb50a0b001WFK7AMDV45cF8Z"
+      ],
+      "display_line": 86,
+      "key": "C",
+      "range": {
+        "from": 82,
+        "to": 86
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_9efb50a0b001WFK7AMDV45cF8Z"
+      ],
+      "display_line": 86,
+      "key": "F",
+      "range": {
+        "from": 82,
+        "to": 86
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    },
+    {
+      "args": [
+        "msg_9efb59d93001LSm9y0DS9p8cP6"
+      ],
+      "display_line": 114,
+      "key": "R",
+      "range": {
+        "from": 110,
+        "to": 114
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_9efb59d93001LSm9y0DS9p8cP6"
+      ],
+      "display_line": 114,
+      "key": "C",
+      "range": {
+        "from": 110,
+        "to": 114
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_9efb59d93001LSm9y0DS9p8cP6"
+      ],
+      "display_line": 114,
+      "key": "F",
+      "range": {
+        "from": 110,
+        "to": 114
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/simple-session.expected.json
+++ b/tests/data/simple-session.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_9cf8f64de0016tbfTQqWMydbdr"
+      ],
+      "display_line": 8,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 8
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_9cf8f64de0016tbfTQqWMydbdr"
+      ],
+      "display_line": 8,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 8
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_9cf8f64de0016tbfTQqWMydbdr"
+      ],
+      "display_line": 8,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 8
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/updating-text.expected.json
+++ b/tests/data/updating-text.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_9d0297a630014CA5ly3Vvw8Kt5"
+      ],
+      "display_line": 6,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_9d0297a630014CA5ly3Vvw8Kt5"
+      ],
+      "display_line": 6,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_9d0297a630014CA5ly3Vvw8Kt5"
+      ],
+      "display_line": 6,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 6
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/data/user-message-metadata-update.expected.json
+++ b/tests/data/user-message-metadata-update.expected.json
@@ -1,5 +1,45 @@
 {
-  "actions": [],
+  "actions": [
+    {
+      "args": [
+        "msg_user_metadata_update"
+      ],
+      "display_line": 4,
+      "key": "R",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[R]evert",
+      "type": "undo"
+    },
+    {
+      "args": [
+        "msg_user_metadata_update"
+      ],
+      "display_line": 4,
+      "key": "C",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[C]opy",
+      "type": "copy_message"
+    },
+    {
+      "args": [
+        "msg_user_metadata_update"
+      ],
+      "display_line": 4,
+      "key": "F",
+      "range": {
+        "from": 0,
+        "to": 4
+      },
+      "text": "[F]ork",
+      "type": "fork_session"
+    }
+  ],
   "extmarks": [
     [
       1,

--- a/tests/unit/api_spec.lua
+++ b/tests/unit/api_spec.lua
@@ -269,6 +269,39 @@ describe('opencode.api', function()
       assert.is_function(api.question_other)
 
       assert.is_function(api.open_input_new_session_with_title)
+      assert.is_function(api.copy_message)
+    end)
+
+    it('routes copy_message through the command axis with its message id', function()
+      local original_active_session = state.active_session
+      local original_messages = state.messages
+      state.session.set_active(mk_session('session-copy'))
+      state.renderer.set_messages({
+        {
+          info = { id = 'message-copy', role = 'user' },
+          parts = { { type = 'text', text = 'copy source' } },
+        },
+      })
+
+      local build_stub = stub(commands, 'build_parsed_intent').invokes(function(name, args)
+        assert.equal('copy_message', name)
+        assert.same({ 'message-copy' }, args)
+        return { ok = true, intent = {} }
+      end)
+      local execute_stub = stub(commands, 'execute_parsed_intent').invokes(function(_, action)
+        return action({ 'message-copy' })
+      end)
+      local setreg_stub = stub(vim.fn, 'setreg')
+
+      api.copy_message('message-copy')
+
+      assert.stub(execute_stub).was_called()
+      assert.stub(setreg_stub).was_called_with('+', 'copy source')
+      setreg_stub:revert()
+      execute_stub:revert()
+      build_stub:revert()
+      state.renderer.set_messages(original_messages)
+      state.session.set_active(original_active_session)
     end)
   end)
 

--- a/tests/unit/commands_handlers_spec.lua
+++ b/tests/unit/commands_handlers_spec.lua
@@ -583,4 +583,88 @@ describe('opencode.commands.handlers', function()
     assert.is_true(called_with.wrap)
     assert.equal('noop', called_with.empty_policy)
   end)
+
+  describe('copy_message', function()
+    local state
+    local active_session
+    local messages
+
+    before_each(function()
+      state = require('opencode.state')
+      active_session = state.active_session
+      messages = state.messages
+      state.session.set_active({ id = 'session-copy' })
+    end)
+
+    after_each(function()
+      state.session.set_active(active_session)
+      state.renderer.set_messages(messages)
+    end)
+
+    it('copies original non-synthetic text parts in order without trimming', function()
+      state.renderer.set_messages({
+        {
+          info = { id = 'user-message', role = 'user' },
+          parts = {
+            { type = 'text', text = '  first  ' },
+            { type = 'text', text = 'synthetic', synthetic = true },
+            { type = 'tool', text = 'tool output' },
+            { type = 'text', text = nil },
+            { type = 'text', text = 1 },
+            { type = 'text', text = 'second\nline' },
+            { type = 'text', text = '   ' },
+          },
+        },
+      })
+      local setreg_stub = stub(vim.fn, 'setreg')
+
+      require('opencode.commands.handlers.session').actions.copy_message('user-message')
+
+      assert.stub(setreg_stub).was_called_with('+', '  first  \n\nsecond\nline')
+      setreg_stub:revert()
+    end)
+
+    it('does not replace the register when no valid message text exists', function()
+      state.renderer.set_messages({
+        {
+          info = { id = 'empty-message', role = 'user' },
+          parts = {
+            { type = 'text', text = ' ', synthetic = false },
+            { type = 'text', text = nil },
+            { type = 'text', text = false },
+            { type = 'tool', text = 'tool output' },
+          },
+        },
+      })
+      local setreg_stub = stub(vim.fn, 'setreg')
+      local notify_stub = stub(vim, 'notify')
+
+      require('opencode.commands.handlers.session').actions.copy_message('empty-message')
+
+      assert.stub(setreg_stub).was_not_called()
+      assert.stub(notify_stub).was_called_with('No message text to copy', vim.log.levels.WARN)
+      notify_stub:revert()
+      setreg_stub:revert()
+    end)
+
+    it('does not copy missing or non-user messages', function()
+      state.renderer.set_messages({
+        {
+          info = { id = 'assistant-message', role = 'assistant' },
+          parts = { { type = 'text', text = 'assistant text' } },
+        },
+      })
+      local setreg_stub = stub(vim.fn, 'setreg')
+      local notify_stub = stub(vim, 'notify')
+      local session = require('opencode.commands.handlers.session')
+
+      session.actions.copy_message('missing-message')
+      session.actions.copy_message('assistant-message')
+
+      assert.stub(setreg_stub).was_not_called()
+      assert.stub(notify_stub).was_called_with('No user message to copy', vim.log.levels.WARN)
+      notify_stub:revert()
+      setreg_stub:revert()
+    end)
+  end)
 end)

--- a/tests/unit/contextual_actions_spec.lua
+++ b/tests/unit/contextual_actions_spec.lua
@@ -1,0 +1,360 @@
+local assert = require('luassert')
+local stub = require('luassert.stub')
+local state = require('opencode.state')
+local contextual_actions = require('opencode.ui.contextual_actions')
+
+local function mapping(buf, key)
+  for _, value in ipairs(vim.api.nvim_buf_get_keymap(buf, 'n')) do
+    if value.lhs == key then
+      return value
+    end
+  end
+end
+
+local function action(key, type, args, range)
+  return {
+    key = key,
+    text = key,
+    type = type,
+    args = args,
+    display_line = range and range.to or 0,
+    range = range,
+  }
+end
+
+describe('contextual actions', function()
+  local buf
+  local windows
+
+  before_each(function()
+    windows = state.store.get('windows')
+    buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'text' })
+    vim.api.nvim_set_current_buf(buf)
+    state.store.set_raw('windows', { output_buf = buf })
+  end)
+
+  after_each(function()
+    state.store.set_raw('windows', windows)
+    if vim.api.nvim_buf_is_valid(buf) then
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end
+  end)
+
+  it('reversibly overlays and restores buffer-local callback mappings', function()
+    local original = function()
+      return ''
+    end
+    vim.keymap.set('n', 'R', original, {
+      buffer = buf,
+      desc = 'Original R',
+      silent = true,
+      expr = true,
+      nowait = true,
+      remap = true,
+      replace_keycodes = false,
+    })
+
+    contextual_actions.show_contextual_actions_menu(buf, { action('R') })
+    assert.equal('R', mapping(buf, 'R').desc)
+
+    contextual_actions.show_contextual_actions_menu(buf, {})
+    local restored = mapping(buf, 'R')
+    assert.equal(original, restored.callback)
+    assert.equal('Original R', restored.desc)
+    assert.equal(1, restored.silent)
+    assert.equal(1, restored.expr)
+    assert.equal(1, restored.nowait)
+    assert.equal(0, restored.noremap)
+    assert.not_equal(1, restored.replace_keycodes)
+  end)
+
+  it('keeps an originally unmapped key unmapped after invalidation', function()
+    contextual_actions.show_contextual_actions_menu(buf, { action('C') })
+    assert.equal('C', mapping(buf, 'C').desc)
+
+    contextual_actions.show_contextual_actions_menu(buf, {})
+    assert.is_nil(mapping(buf, 'C'))
+  end)
+
+  it('restores buffer-local rhs mappings', function()
+    vim.keymap.set('n', 'C', "<Cmd>echo 'original'<CR>", { buffer = buf, desc = 'Original C' })
+
+    contextual_actions.show_contextual_actions_menu(buf, { action('C') })
+    contextual_actions.show_contextual_actions_menu(buf, {})
+
+    assert.equal("<Cmd>echo 'original'<CR>", mapping(buf, 'C').rhs)
+    assert.equal('Original C', mapping(buf, 'C').desc)
+  end)
+
+  it('preserves script-local rhs mappings through an action overlay', function()
+    local script = vim.fn.tempname()
+    vim.fn.writefile({
+      'function! s:contextual_action_probe() abort',
+      "  let g:opencode_contextual_action_probe = get(g:, 'opencode_contextual_action_probe', 0) + 1",
+      'endfunction',
+      'nnoremap <script> <buffer> R :call <SID>contextual_action_probe()<CR>',
+    }, script)
+    vim.cmd('source ' .. vim.fn.fnameescape(script))
+    vim.fn.delete(script)
+    local original = mapping(buf, 'R')
+
+    contextual_actions.show_contextual_actions_menu(buf, { action('R') })
+    contextual_actions.show_contextual_actions_menu(buf, {})
+
+    local restored = mapping(buf, 'R')
+    assert.equal(original.rhs, restored.rhs)
+    assert.equal(original.script, restored.script)
+    vim.g.opencode_contextual_action_probe = nil
+    vim.api.nvim_feedkeys('R', 'xt', false)
+    assert.equal(1, vim.g.opencode_contextual_action_probe)
+  end)
+
+  it('restores callback and script-local mappings with their native options', function()
+    local script = vim.fn.tempname()
+    vim.fn.writefile({
+      'function! s:contextual_action_probe() abort',
+      "  let g:opencode_contextual_action_probe = get(g:, 'opencode_contextual_action_probe', 0) + 1",
+      'endfunction',
+      'nnoremap <script> <buffer> S :call <SID>contextual_action_probe()<CR>',
+    }, script)
+    vim.cmd('source ' .. vim.fn.fnameescape(script))
+    vim.fn.delete(script)
+    local callback_calls = 0
+    vim.api.nvim_buf_set_keymap(buf, 'n', 'R', '', {
+      callback = function()
+        callback_calls = callback_calls + 1
+        return ''
+      end,
+      desc = 'Original R',
+      expr = true,
+      noremap = true,
+      nowait = true,
+      replace_keycodes = false,
+      script = true,
+      silent = true,
+    })
+    local original = mapping(buf, 'R')
+
+    contextual_actions.show_contextual_actions_menu(buf, { action('R'), action('S') })
+    contextual_actions.show_contextual_actions_menu(buf, {})
+
+    local restored = mapping(buf, 'R')
+    assert.equal(original.callback, restored.callback)
+    assert.equal(1, restored.expr)
+    assert.equal(2, restored.noremap)
+    assert.equal(1, restored.nowait)
+    assert.not_equal(1, restored.replace_keycodes)
+    assert.equal(1, restored.script)
+    assert.equal(1, restored.silent)
+    restored.callback()
+    assert.equal(1, callback_calls)
+    vim.g.opencode_contextual_action_probe = nil
+    vim.api.nvim_feedkeys('S', 'xt', false)
+    assert.equal(1, vim.g.opencode_contextual_action_probe)
+  end)
+
+  it('attaches one observer and invalidates once when buffer lines change', function()
+    local original_attach = vim.api.nvim_buf_attach
+    local attach = stub(vim.api, 'nvim_buf_attach').invokes(original_attach)
+    contextual_actions.setup_contextual_actions({ output_buf = buf })
+    contextual_actions.setup_contextual_actions({ output_buf = buf })
+    assert.equal(1, #attach.calls)
+    attach:revert()
+
+    vim.keymap.set('n', 'R', function() end, { buffer = buf, desc = 'Original R' })
+    contextual_actions.show_contextual_actions_menu(buf, { action('R') })
+    local original_clear_namespace = vim.api.nvim_buf_clear_namespace
+    local clear_namespace = stub(vim.api, 'nvim_buf_clear_namespace').invokes(original_clear_namespace)
+
+    vim.api.nvim_buf_set_lines(buf, 0, 1, false, { 'changed' })
+
+    assert.stub(clear_namespace).was_called(1)
+    assert.equal('Original R', mapping(buf, 'R').desc)
+    clear_namespace:revert()
+  end)
+
+  it('clears actions on cursor and buffer lifecycle events, then can show them again', function()
+    contextual_actions.setup_contextual_actions({ output_buf = buf })
+    vim.keymap.set('n', 'R', function() end, { buffer = buf, desc = 'Original R' })
+
+    contextual_actions.show_contextual_actions_menu(buf, { action('R') })
+    vim.api.nvim_exec_autocmds('CursorMoved', { buffer = buf })
+    assert.equal('Original R', mapping(buf, 'R').desc)
+
+    contextual_actions.show_contextual_actions_menu(buf, { action('R') })
+    vim.api.nvim_exec_autocmds('BufHidden', { buffer = buf })
+    assert.equal('Original R', mapping(buf, 'R').desc)
+
+    local renderer = package.loaded['opencode.ui.renderer']
+    package.loaded['opencode.ui.renderer'] = {
+      get_actions_for_line = function()
+        return { action('R') }
+      end,
+    }
+    vim.api.nvim_exec_autocmds('CursorHold', { buffer = buf })
+    assert.is_true(vim.wait(100, function()
+      return mapping(buf, 'R') and mapping(buf, 'R').desc == 'R'
+    end))
+    package.loaded['opencode.ui.renderer'] = renderer
+  end)
+
+  it('refreshes actions on setup and output re-entry', function()
+    vim.keymap.set('n', 'R', function() end, { buffer = buf, desc = 'Original R' })
+    local renderer = package.loaded['opencode.ui.renderer']
+    package.loaded['opencode.ui.renderer'] = {
+      get_actions_for_line = function()
+        return { action('R') }
+      end,
+    }
+
+    contextual_actions.setup_contextual_actions({ output_buf = buf })
+    assert.equal('R', mapping(buf, 'R').desc)
+
+    vim.api.nvim_exec_autocmds('BufLeave', { buffer = buf })
+    assert.equal('Original R', mapping(buf, 'R').desc)
+    vim.api.nvim_exec_autocmds('BufEnter', { buffer = buf })
+    assert.equal('R', mapping(buf, 'R').desc)
+
+    vim.api.nvim_exec_autocmds('BufLeave', { buffer = buf })
+    vim.api.nvim_exec_autocmds('WinEnter', { buffer = buf })
+    assert.equal('R', mapping(buf, 'R').desc)
+    package.loaded['opencode.ui.renderer'] = renderer
+  end)
+
+  it('refreshes a persistent output buffer when setup runs again', function()
+    vim.keymap.set('n', 'R', function() end, { buffer = buf, desc = 'Original R' })
+    local renderer = package.loaded['opencode.ui.renderer']
+    package.loaded['opencode.ui.renderer'] = {
+      get_actions_for_line = function()
+        return { action('R') }
+      end,
+    }
+
+    contextual_actions.setup_contextual_actions({ output_buf = buf })
+    vim.api.nvim_exec_autocmds('BufHidden', { buffer = buf })
+    assert.equal('Original R', mapping(buf, 'R').desc)
+
+    contextual_actions.setup_contextual_actions({ output_buf = buf })
+    assert.equal('R', mapping(buf, 'R').desc)
+    package.loaded['opencode.ui.renderer'] = renderer
+  end)
+
+  it('does not redraw contextual actions while the cursor stays in their range', function()
+    contextual_actions.setup_contextual_actions({ output_buf = buf })
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'header', 'text', 'context', '' })
+    vim.keymap.set('n', 'R', function() end, { buffer = buf, desc = 'Original R' })
+
+    local renderer = package.loaded['opencode.ui.renderer']
+    package.loaded['opencode.ui.renderer'] = {
+      get_actions_for_line = function()
+        return { action('R', 'undo', { 'message-one' }, { from = 0, to = 3 }) }
+      end,
+    }
+
+    vim.api.nvim_exec_autocmds('CursorMoved', { buffer = buf })
+    assert.equal('R', mapping(buf, 'R').desc)
+
+    local clear_namespace = stub(vim.api, 'nvim_buf_clear_namespace').invokes(vim.api.nvim_buf_clear_namespace)
+    local set_mapping = stub(vim.keymap, 'set').invokes(vim.keymap.set)
+    vim.api.nvim_win_set_cursor(0, { 4, 0 })
+    vim.api.nvim_exec_autocmds('CursorMoved', { buffer = buf })
+
+    assert.equal(0, #clear_namespace.calls)
+    assert.equal(0, #set_mapping.calls)
+    assert.equal('R', mapping(buf, 'R').desc)
+    clear_namespace:revert()
+    set_mapping:revert()
+    package.loaded['opencode.ui.renderer'] = renderer
+  end)
+
+  it('shows, replaces, and clears contextual actions through CursorMoved', function()
+    contextual_actions.setup_contextual_actions({ output_buf = buf })
+    vim.api.nvim_buf_set_lines(
+      buf,
+      0,
+      -1,
+      false,
+      { 'user one header', 'user one text', '', 'assistant', 'user two header', 'user two text', '' }
+    )
+    vim.keymap.set('n', 'R', function() end, { buffer = buf, desc = 'Original R' })
+
+    local renderer = package.loaded['opencode.ui.renderer']
+    local api = package.loaded['opencode.api']
+    local calls = {}
+    package.loaded['opencode.ui.renderer'] = {
+      get_actions_for_line = function(line)
+        if line <= 2 then
+          return { action('R', 'undo', { 'message-one' }, { from = 0, to = 2 }) }
+        end
+        if line >= 4 and line <= 6 then
+          return { action('R', 'undo', { 'message-two' }, { from = 4, to = 6 }) }
+        end
+      end,
+    }
+    package.loaded['opencode.api'] = {
+      undo = function(id)
+        calls[#calls + 1] = id
+      end,
+    }
+
+    vim.api.nvim_exec_autocmds('CursorMoved', { buffer = buf })
+    assert.equal('R', mapping(buf, 'R').desc)
+    mapping(buf, 'R').callback()
+
+    vim.api.nvim_win_set_cursor(0, { 5, 0 })
+    vim.api.nvim_exec_autocmds('CursorMoved', { buffer = buf })
+    assert.equal('R', mapping(buf, 'R').desc)
+    mapping(buf, 'R').callback()
+
+    vim.api.nvim_win_set_cursor(0, { 4, 0 })
+    vim.api.nvim_exec_autocmds('CursorMoved', { buffer = buf })
+    assert.equal('Original R', mapping(buf, 'R').desc)
+    assert.same({ 'message-one', 'message-two' }, calls)
+    package.loaded['opencode.ui.renderer'] = renderer
+    package.loaded['opencode.api'] = api
+  end)
+
+  it('keeps another buffer lifecycle isolated from an old buffer observer', function()
+    contextual_actions.setup_contextual_actions({ output_buf = buf })
+    contextual_actions.show_contextual_actions_menu(buf, { action('R') })
+
+    local other = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(other, 0, -1, false, { 'other' })
+    contextual_actions.setup_contextual_actions({ output_buf = other })
+    contextual_actions.show_contextual_actions_menu(other, { action('C') })
+
+    vim.api.nvim_buf_set_lines(buf, 0, 1, false, { 'changed' })
+    assert.equal('C', mapping(other, 'C').desc)
+    vim.api.nvim_buf_delete(other, { force = true })
+  end)
+
+  it('dispatches R/C/F through opencode.api with the original message id', function()
+    contextual_actions.setup_contextual_actions({ output_buf = buf })
+    local api = package.loaded['opencode.api']
+    local calls = {}
+    package.loaded['opencode.api'] = {
+      undo = function(id)
+        calls.undo = id
+      end,
+      copy_message = function(id)
+        calls.copy_message = id
+      end,
+      fork_session = function(id)
+        calls.fork_session = id
+      end,
+    }
+
+    for _, value in ipairs({
+      action('R', 'undo', { 'message-r' }),
+      action('C', 'copy_message', { 'message-c' }),
+      action('F', 'fork_session', { 'message-f' }),
+    }) do
+      contextual_actions.show_contextual_actions_menu(buf, { value })
+      mapping(buf, value.key).callback()
+    end
+
+    package.loaded['opencode.api'] = api
+    assert.same({ undo = 'message-r', copy_message = 'message-c', fork_session = 'message-f' }, calls)
+  end)
+end)

--- a/tests/unit/contextual_actions_spec.lua
+++ b/tests/unit/contextual_actions_spec.lua
@@ -357,4 +357,25 @@ describe('contextual actions', function()
     package.loaded['opencode.api'] = api
     assert.same({ undo = 'message-r', copy_message = 'message-c', fork_session = 'message-f' }, calls)
   end)
+
+  it('ignores a callback from a replaced action set', function()
+    contextual_actions.setup_contextual_actions({ output_buf = buf })
+    local api = package.loaded['opencode.api']
+    local calls = {}
+    package.loaded['opencode.api'] = {
+      undo = function(id)
+        calls[#calls + 1] = id
+      end,
+    }
+
+    contextual_actions.show_contextual_actions_menu(buf, { action('R', 'undo', { 'old-message' }) })
+    local stale_callback = mapping(buf, 'R').callback
+    contextual_actions.show_contextual_actions_menu(buf, { action('R', 'undo', { 'current-message' }) })
+    stale_callback()
+
+    assert.same({}, calls)
+    mapping(buf, 'R').callback()
+    assert.same({ 'current-message' }, calls)
+    package.loaded['opencode.api'] = api
+  end)
 end)

--- a/tests/unit/formatter_spec.lua
+++ b/tests/unit/formatter_spec.lua
@@ -1125,5 +1125,15 @@ describe('formatter', function()
       local output = formatter.format_part(make_bash_part(), message, true)
       assert.is_true(#output.fold_ranges > 0)
     end)
+
+    describe('message actions', function()
+      it('does not assign R/C/F to an individual user text part', function()
+        local message = { info = { id = 'msg-user', role = 'user' }, parts = {} }
+        local output = formatter.format_part({ type = 'text', text = 'first\nsecond' }, message, true, {})
+
+        assert.same({ 'first', 'second', '' }, output.lines)
+        assert.same({}, output.actions)
+      end)
+    end)
   end)
 end)

--- a/tests/unit/persist_state_spec.lua
+++ b/tests/unit/persist_state_spec.lua
@@ -465,7 +465,7 @@ describe('persist_state', function()
 
       assert.equals('Temporary A', mapping_description('a'))
       toggle_wait('hidden')
-      assert.is_nil(mapping_description('a'))
+      assert.equals('Base A', mapping_description('a'))
 
       toggle_wait('visible')
       assert.equals('Base A', mapping_description('a'))

--- a/tests/unit/render_state_spec.lua
+++ b/tests/unit/render_state_spec.lua
@@ -250,6 +250,95 @@ describe('RenderState', function()
       assert.equals('action1', line_actions[1].type)
     end)
 
+    it('owns one R/C/F set across an actionable user message block', function()
+      local message = {
+        info = { id = 'msg-user', role = 'user' },
+        parts = {
+          { id = 'text-part', messageID = 'msg-user', type = 'text', text = 'prompt' },
+          { id = 'file-part', messageID = 'msg-user', type = 'file', filename = 'file.lua' },
+        },
+      }
+      render_state:set_message(message, 20, 21)
+      render_state:set_part(message.parts[1], 22, 24)
+      render_state:set_part(message.parts[2], 25, 26)
+
+      local rendered = render_state:get_message('msg-user')
+      assert.equals(3, #rendered.actions)
+      assert.same({ from = 20, to = 26 }, rendered.actions[1].range)
+      assert.same(
+        { 'undo', 'copy_message', 'fork_session' },
+        vim.tbl_map(function(action)
+          return action.type
+        end, rendered.actions)
+      )
+
+      for line = 20, 26 do
+        local actions = render_state:get_actions_at_line(line)
+        assert.equals(3, #actions)
+        assert.same({ 'msg-user' }, actions[1].args)
+      end
+    end)
+
+    it('refreshes message actions after a header expansion shifts its parts', function()
+      local message = {
+        info = { id = 'msg-user', role = 'user' },
+        parts = {
+          { id = 'text-part', messageID = 'msg-user', type = 'text', text = 'prompt' },
+          { id = 'file-part', messageID = 'msg-user', type = 'file', filename = 'file.lua' },
+        },
+      }
+      render_state:set_message(message, 10, 11)
+      render_state:set_part(message.parts[1], 12, 13)
+      render_state:set_part(message.parts[2], 14, 15)
+
+      render_state:set_message(message, 10, 13)
+      render_state:shift_all(12, 2)
+
+      local action = render_state:get_message('msg-user').actions[1]
+      assert.same({ from = 10, to = 17 }, action.range)
+      assert.same({ 'msg-user' }, render_state:get_actions_at_line(17)[1].args)
+    end)
+
+    it('keeps message actions within the block after the closest header', function()
+      local user_one = {
+        info = { id = 'user-one', role = 'user' },
+        parts = { { id = 'user-one-text', messageID = 'user-one', type = 'text', text = 'first' } },
+      }
+      local assistant = {
+        info = { id = 'assistant', role = 'assistant' },
+        parts = { { id = 'assistant-text', messageID = 'assistant', type = 'text', text = 'reply' } },
+      }
+      local user_two = {
+        info = { id = 'user-two', role = 'user' },
+        parts = { { id = 'user-two-text', messageID = 'user-two', type = 'text', text = 'second' } },
+      }
+      render_state:set_message(user_one, 10, 11)
+      render_state:set_part(user_one.parts[1], 12, 14)
+      render_state:set_message(assistant, 15, 16)
+      render_state:set_part(assistant.parts[1], 17, 18)
+      render_state:set_message(user_two, 19, 20)
+      render_state:set_part(user_two.parts[1], 21, 23)
+
+      assert.same({ 'user-one' }, render_state:get_actions_at_line(10)[1].args)
+      assert.same({ 'user-one' }, render_state:get_actions_at_line(14)[1].args)
+      assert.same({}, render_state:get_actions_at_line(17))
+      assert.same({ 'user-two' }, render_state:get_actions_at_line(19)[1].args)
+      assert.same({ 'user-two' }, render_state:get_actions_at_line(23)[1].args)
+    end)
+
+    it('requires a non-synthetic non-empty user text part for message actions', function()
+      for _, message in ipairs({
+        { info = { id = 'assistant', role = 'assistant' }, parts = { { type = 'text', text = 'text' } } },
+        { info = { id = 'system', role = 'system' }, parts = { { type = 'text', text = 'text' } } },
+        { info = { id = '', role = 'user' }, parts = { { type = 'text', text = 'text' } } },
+        { info = { id = 'synthetic', role = 'user' }, parts = { { type = 'text', text = 'text', synthetic = true } } },
+        { info = { id = 'empty', role = 'user' }, parts = { { type = 'text', text = '  ' } } },
+      }) do
+        render_state:set_message(message, 30, 31)
+        assert.same({}, render_state:get_actions_at_line(30))
+      end
+    end)
+
     it('gets all actions from all parts', function()
       local part1 = { id = 'part1', messageID = 'msg1' }
       local part2 = { id = 'part2', messageID = 'msg1' }


### PR DESCRIPTION
## Summary

- expose Revert, Copy, and Fork through the existing contextual actions UI
- keep one action set across the full rendered user message range
- restore overwritten buffer-local mappings when contextual actions become inactive
- copy original non-synthetic user text through the existing API command axis

## Model

```text
state.messages                         RenderState
├── message id ──> undo / fork         └── user message range
└── original text ──> copy                 └── R / C / F

cursor line ──> actions in range ──> temporary mappings ──> opencode.api
                       │
                       └── leave range ──> restore previous mappings
```

## Testing

- `./run_tests.sh`
- 138 replay cases
- contextual action mapping, persistent-buffer, range-shift, and Copy contract coverage

Closes the interaction gap discussed in #439 by reusing contextual actions instead of adding another dialog or mouse-specific surface.